### PR TITLE
Keep cron secrets in memory-backed files

### DIFF
--- a/.circleci/run_local.sh
+++ b/.circleci/run_local.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -euo pipefail
+
+job="${1:-312}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+postgres_container="pdk-circleci-postgres-${job}-$$"
+
+cleanup() {
+  docker rm -f "$postgres_container" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+case "$job" in
+  312)
+    python_image="cimg/python:3.12"
+    postgres_image="cimg/postgres:14.18-postgis"
+    venv_command='python3 -m venv --copies /home/circleci/venv'
+    startproject_command='django-admin startproject pdk'
+    ;;
+  310)
+    python_image="cimg/python:3.10"
+    postgres_image="cimg/postgres:14.18-postgis"
+    venv_command='python3 -m venv --copies /home/circleci/venv'
+    startproject_command='django-admin startproject pdk'
+    ;;
+  39)
+    python_image="cimg/python:3.9"
+    postgres_image="cimg/postgres:12.18-postgis"
+    venv_command='python3 -m venv --copies /home/circleci/venv'
+    startproject_command='django-admin startproject pdk'
+    ;;
+  38)
+    python_image="cimg/python:3.8"
+    postgres_image="cimg/postgres:12.18-postgis"
+    venv_command='python3 -m venv --copies /home/circleci/venv'
+    startproject_command='django-admin startproject pdk'
+    ;;
+  37)
+    python_image="cimg/python:3.7"
+    postgres_image="cimg/postgres:9.6-postgis"
+    venv_command='python3 -m venv --copies /home/circleci/venv'
+    startproject_command='django-admin.py startproject pdk'
+    ;;
+  36)
+    python_image="cimg/python:3.6"
+    postgres_image="cimg/postgres:9.6-postgis"
+    venv_command='python3 -m venv --copies /home/circleci/venv'
+    startproject_command='django-admin.py startproject pdk'
+    ;;
+  27)
+    python_image="cimg/python:2.7"
+    postgres_image="cimg/postgres:9.6-postgis"
+    venv_command='virtualenv --copies /home/circleci/venv'
+    startproject_command='django-admin.py startproject pdk'
+    ;;
+  *)
+    echo "Unknown CircleCI job version: $job" >&2
+    echo "Expected one of: 312 310 39 38 37 36 27" >&2
+    exit 1
+    ;;
+esac
+
+echo "Starting ${postgres_image} as ${postgres_container}..."
+docker run -d \
+  --name "$postgres_container" \
+  -e POSTGRES_USER=root \
+  -e POSTGRES_DB=circle_test \
+  -e POSTGRES_PASSWORD= \
+  "$postgres_image" >/dev/null
+
+echo "Waiting for Postgres to become healthy..."
+for _ in $(seq 1 60); do
+  status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$postgres_container")"
+
+  if [[ "$status" == "healthy" || "$status" == "running" ]]; then
+    break
+  fi
+
+  sleep 2
+done
+
+status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$postgres_container")"
+
+if [[ "$status" != "healthy" && "$status" != "running" ]]; then
+  echo "Postgres container did not become ready." >&2
+  docker logs "$postgres_container" >&2 || true
+  exit 1
+fi
+
+echo "Running CircleCI build-${job} locally with ${python_image}..."
+docker run --rm \
+  --network "container:${postgres_container}" \
+  -v "${repo_root}:/mnt/project:ro" \
+  -w /mnt/project \
+  "$python_image" \
+  /bin/bash -lc "
+    set -euo pipefail
+    sudo apt-get update && sudo apt-get install -y gdal-bin
+    ${venv_command}
+    . /home/circleci/venv/bin/activate
+    pip install -U pip
+    pip install wheel
+    rm -rf /tmp/circleci-run
+    mkdir -p /tmp/circleci-run/project
+    cp -a /mnt/project/. /tmp/circleci-run/project/
+    cd /tmp/circleci-run/project
+    pip install -r requirements.txt --progress-bar off
+    cd ..
+    rm -rf django passive_data_kit
+    mv project passive_data_kit
+    mkdir django
+    cd django
+    ${startproject_command}
+    mv ../passive_data_kit pdk
+    cd pdk
+    cp passive_data_kit/.circleci/circle_settings.py pdk/settings.py
+    cp passive_data_kit/.circleci/circle_urls.py pdk/urls.py
+    python manage.py migrate
+    python manage.py pdk_generate_backup_key
+    python manage.py test
+    cp passive_data_kit/.pylintrc .
+    pylint passive_data_kit
+    bandit -r .
+  "

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,10 +1,10 @@
 SHELL=/bin/bash
 MAILTO=root
 
-* * * * *    root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_process_bundles |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_process_bundles" $CRON_MAIL_RECIPIENT
-0 3 * * *    root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_clear_processed_bundles |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_clear_processed_bundles" $CRON_MAIL_RECIPIENT
-*/15 * * * * root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_update_server_health |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_update_server_health" $CRON_MAIL_RECIPIENT
-* * * * *    root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_compile_reports |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_compile_reports" $CRON_MAIL_RECIPIENT
-*/5 * * * *  root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_update_performance_metadata |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_compile_reports" $CRON_MAIL_RECIPIENT
-*/5 * * * *  root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_compile_visualizations |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_compile_visualizations" $CRON_MAIL_RECIPIENT
-*/5 * * * *  root   . /etc/environment && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_run_status_checks |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_run_status_checks" $CRON_MAIL_RECIPIENT
+* * * * *    root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_process_bundles |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_process_bundles" "$CRON_MAIL_RECIPIENT"
+0 3 * * *    root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_clear_processed_bundles |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_clear_processed_bundles" "$CRON_MAIL_RECIPIENT"
+*/15 * * * * root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_update_server_health |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_update_server_health" "$CRON_MAIL_RECIPIENT"
+* * * * *    root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_compile_reports |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_compile_reports" "$CRON_MAIL_RECIPIENT"
+*/5 * * * *  root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_update_performance_metadata |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_compile_reports" "$CRON_MAIL_RECIPIENT"
+*/5 * * * *  root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_compile_visualizations |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_compile_visualizations" "$CRON_MAIL_RECIPIENT"
+*/5 * * * *  root   . /dev/shm/cron.env && . /app/venv/bin/activate && python3 /app/live_site/manage.py pdk_run_status_checks |& tee -a /var/log/cron.log | ifne mail -s "[$PROJECT_HOSTNAME]: pdk_run_status_checks" "$CRON_MAIL_RECIPIENT"

--- a/docker/cron/run.sh
+++ b/docker/cron/run.sh
@@ -1,15 +1,55 @@
 #!/bin/bash
 
-echo "root=$CRON_MAIL_RECIPIENT" > /etc/ssmtp/ssmtp.conf
-echo "mailhub=$CRON_MAIL_SERVER" >> /etc/ssmtp/ssmtp.conf
-echo "rewriteDomain=$CRON_MAIL_DOMAIN" >> /etc/ssmtp/ssmtp.conf
-echo "hostname=$CRON_SENDER_HOSTNAME" >> /etc/ssmtp/ssmtp.conf
-echo "UseTLS=Yes" >> /etc/ssmtp/ssmtp.conf
-echo "UseSTARTTLS=Yes" >> /etc/ssmtp/ssmtp.conf
-echo "FromLineOverride=No" >> /etc/ssmtp/ssmtp.conf
-echo "AuthUser=$CRON_MAIL_USERNAME" >> /etc/ssmtp/ssmtp.conf
-echo "AuthPass=$CRON_MAIL_PASSWORD" >> /etc/ssmtp/ssmtp.conf
+set -euo pipefail
 
-printenv
+SSMTP_CONFIG="/dev/shm/ssmtp.conf"
+CRON_ENV="/dev/shm/cron.env"
+
+write_shell_var() {
+  local name="$1"
+  local value="${2-}"
+
+  printf "export %s=%q\n" "$name" "$value" >> "$CRON_ENV"
+}
+
+cat > "$SSMTP_CONFIG" <<EOF
+root=$CRON_MAIL_RECIPIENT
+mailhub=$CRON_MAIL_SERVER
+rewriteDomain=$CRON_MAIL_DOMAIN
+hostname=$CRON_SENDER_HOSTNAME
+UseTLS=Yes
+UseSTARTTLS=Yes
+FromLineOverride=No
+AuthUser=$CRON_MAIL_USERNAME
+AuthPass=$CRON_MAIL_PASSWORD
+EOF
+
+chmod 600 "$SSMTP_CONFIG"
+ln -sf "$SSMTP_CONFIG" /etc/ssmtp/ssmtp.conf
+
+: > "$CRON_ENV"
+chmod 600 "$CRON_ENV"
+
+write_shell_var "DJANGO_HOST" "${DJANGO_HOST-}"
+write_shell_var "DJANGO_WEB_PORT" "${DJANGO_WEB_PORT-}"
+write_shell_var "DJANGO_SECRET_KEY" "${DJANGO_SECRET_KEY-}"
+write_shell_var "DJANGO_ADMIN_NAME" "${DJANGO_ADMIN_NAME-}"
+write_shell_var "DJANGO_ADMIN_EMAIL" "${DJANGO_ADMIN_EMAIL-}"
+write_shell_var "DJANGO_DEBUG" "${DJANGO_DEBUG-}"
+write_shell_var "DJANGO_ALLOWED_HOST" "${DJANGO_ALLOWED_HOST-}"
+write_shell_var "PROJECT_HOSTNAME" "${PROJECT_HOSTNAME-}"
+
+write_shell_var "PG_DB" "${PG_DB-}"
+write_shell_var "PG_SERVER" "${PG_SERVER-}"
+write_shell_var "PG_USER" "${PG_USER-}"
+write_shell_var "AWS_REGION" "${AWS_REGION-}"
+write_shell_var "ACCOUNT_ID" "${ACCOUNT_ID-}"
+
+write_shell_var "CRON_MAIL_RECIPIENT" "${CRON_MAIL_RECIPIENT-}"
+write_shell_var "CRON_MAIL_DOMAIN" "${CRON_MAIL_DOMAIN-}"
+write_shell_var "CRON_SENDER_HOSTNAME" "${CRON_SENDER_HOSTNAME-}"
+write_shell_var "CRON_MAIL_SERVER" "${CRON_MAIL_SERVER-}"
+write_shell_var "CRON_MAIL_USERNAME" "${CRON_MAIL_USERNAME-}"
+write_shell_var "CRON_MAIL_PASSWORD" "${CRON_MAIL_PASSWORD-}"
 
 cron && tail -f /var/log/cron.log

--- a/models.py
+++ b/models.py
@@ -127,7 +127,7 @@ def install_supports_jsonfield():
             DB_SUPPORTS_JSON = connection.pg_version >= 90400
         except AttributeError:
             DB_SUPPORTS_JSON = False
-        except: # Added for Postgres-IAM deployment
+        except Exception: # Added for Postgres-IAM deployment # pylint: disable=broad-exception-caught
             DB_SUPPORTS_JSON = True
 
         try:


### PR DESCRIPTION
This is a small change that doesn't change how environment variables are used, but doesn't drop them to persistent storage. It drops them to shared memory.