### PR TITLE
Generalize bundle processing and make bundle uploads atomic

### DIFF
--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -87,12 +87,7 @@ def attach_trace_context(bundle_point, bundle, bundle_trace_id):
     }
 
 
-# Keep the explicit signature to avoid introducing a needless compatibility
-# wrapper structure. Once Python 2 support is dropped, make the optional
-# context keyword-only instead of allowing additional positional arguments.
-def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        bundle, bundle_trace_id, status, properties=None, data_point_id=None, error_class=None):
-def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
+def strip_null_bytes_bad_payload_handler(bundle_point, bundle):  # pylint: disable=invalid-name
     if bundle_point is not None:
         point_json = json.dumps(bundle_point)
 
@@ -105,6 +100,9 @@ def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
     return bundle_point
 
 
+# Keep the explicit signature to avoid introducing a needless compatibility
+# wrapper structure. Once Python 2 support is dropped, make the optional
+# context keyword-only instead of allowing additional positional arguments.
 def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         bundle, bundle_trace_id, status, properties=None, data_point_id=None, error_class=None):
     point_count = None
@@ -146,8 +144,8 @@ class BundleProcessResult:
     mark_processed: bool
 
 
-class BundleProcessingCore(object):
-    def __init__(self, supports_json, default_tz, process_limit, remote_bundle_size, remote_timeout):
+class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attributes,useless-object-inheritance
+    def __init__(self, supports_json, default_tz, process_limit, remote_bundle_size, remote_timeout):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self.supports_json = supports_json
         self.default_tz = default_tz
         self.process_limit = process_limit
@@ -470,7 +468,7 @@ class BundleProcessingCore(object):
         for bundle in self.to_delete:
             bundle.delete()
 
-    def update_stats(self):
+    def update_stats(self):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         data_point_count = DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).first()
 
         if data_point_count is None:

--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -537,3 +537,15 @@ class BundleProcessingCore(object):
 
             latest_datum.value = str(point.pk)
             latest_datum.save()
+
+
+def save_serial_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
+    points = DataPoint.objects.bulk_create(to_record)
+
+    for point in points:
+        record_bundle_processing_trace(bundle, bundle_trace_id, 'data_point_created', data_point_id=point.pk)
+
+        if has_bundles:
+            point.fetch_bundle_files(bundle_files)
+
+    return points

--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -134,8 +134,12 @@ class StopProcessingCurrentBundle(Exception):
     pass
 
 
-class BundleProcessResult:
-    def __init__(self, original_properties, bundle_files, has_bundles, to_record, mark_processed):
+# Python 2.7 / 3.6-era jobs in the Circle matrix cannot rely on dataclasses or
+# class attribute annotations here, so we keep this as a tiny compatibility
+# container. That forces an explicit initializer with several fields, which is
+# why the narrow Pylint suppressions live on this compatibility shim.
+class BundleProcessResult(object):  # pylint: disable=too-few-public-methods,useless-object-inheritance
+    def __init__(self, original_properties, bundle_files, has_bundles, to_record, mark_processed):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self.original_properties = original_properties
         self.bundle_files = bundle_files
         self.has_bundles = has_bundles
@@ -197,7 +201,8 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
             remote_timeout=remote_timeout,
         )
 
-    def mark_bundle_errored(self, bundle_pk, bundle_trace_id, error_class):
+    @staticmethod
+    def mark_bundle_errored(bundle_pk, bundle_trace_id, error_class):
         bundle = DataBundle.objects.get(pk=bundle_pk)
         bundle.errored = timezone.now()
         bundle.save()
@@ -258,12 +263,14 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
 
         return bundle.properties
 
-    def is_ingestable_point(self, bundle_point):
+    @staticmethod
+    def is_ingestable_point(bundle_point):
         return bundle_point is not None and 'passive-data-metadata' in bundle_point and \
                'source' in bundle_point['passive-data-metadata'] and \
                'generator' in bundle_point['passive-data-metadata']
 
-    def prepare_bundle_point(self, bundle_point, bundle, bundle_trace_id):
+    @staticmethod
+    def prepare_bundle_point(bundle_point, bundle, bundle_trace_id):
         source = bundle_point['passive-data-metadata']['source']
 
         if source == '':

--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -92,6 +92,21 @@ def attach_trace_context(bundle_point, bundle, bundle_trace_id):
 # context keyword-only instead of allowing additional positional arguments.
 def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         bundle, bundle_trace_id, status, properties=None, data_point_id=None, error_class=None):
+def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
+    if bundle_point is not None:
+        point_json = json.dumps(bundle_point)
+
+        while r'\u0000' in point_json:
+            print('Detected 0x00 byte in ' + str(bundle.pk) + '. Stripping and ingesting...')
+            point_json = point_json.replace(r'\u0000', '')
+
+        bundle_point = json.loads(point_json)
+
+    return bundle_point
+
+
+def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        bundle, bundle_trace_id, status, properties=None, data_point_id=None, error_class=None):
     point_count = None
 
     if isinstance(properties, list):

--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -1,8 +1,33 @@
-# pylint: disable=no-member
+# pylint: disable=no-member,line-too-long
 
+from __future__ import print_function
+
+from builtins import str # pylint: disable=redefined-builtin
+
+import base64
+import datetime
+import gzip
+import json
+import logging
+import traceback
 import uuid
 
-from .models import DataBundleProcessingTrace
+from dataclasses import dataclass
+from io import BytesIO
+
+import requests
+import six
+
+from nacl.public import PublicKey, PrivateKey, Box
+
+from django.conf import settings
+from django.contrib.gis.geos import GEOSGeometry
+from django.db import DataError
+from django.utils import timezone
+
+from .models import DataBundle, DataBundleProcessingTrace, DataPoint, DataServerMetadatum, DataSource, \
+                    SOURCE_GENERATORS_DATUM, SOURCES_DATUM, TOTAL_DATA_POINT_COUNT_DATUM, \
+                    install_supports_jsonfield
 
 
 def new_bundle_trace_id():
@@ -87,3 +112,428 @@ def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-ma
 
 def record_bundle_deleted(bundle, bundle_trace_id):
     record_bundle_processing_trace(bundle, bundle_trace_id, 'deleted')
+
+
+class BundleProcessingHalt(Exception):
+    pass
+
+
+class StopProcessingCurrentBundle(Exception):
+    pass
+
+
+@dataclass
+class BundleProcessResult:
+    original_properties: object
+    bundle_files: object
+    has_bundles: bool
+    to_record: list
+    mark_processed: bool
+
+
+class BundleProcessingCore(object):
+    def __init__(self, supports_json, default_tz, process_limit, remote_bundle_size, remote_timeout):
+        self.supports_json = supports_json
+        self.default_tz = default_tz
+        self.process_limit = process_limit
+        self.remote_bundle_size = remote_bundle_size
+        self.remote_timeout = remote_timeout
+
+        self.seen_sources = []
+        self.seen_generators = []
+        self.source_identifiers = {}
+        self.latest_points = {}
+
+        self.sources = {}
+        self.xmit_points = {}
+
+        self.private_key = None
+        self.public_key = None
+
+        self.to_delete = []
+        self.new_point_count = 0
+        self.processed_bundle_count = 0
+        self.bundle_size = 0
+        self.start_processing = timezone.now()
+
+    @classmethod
+    def from_settings(cls):
+        process_limit = 1000
+        remote_bundle_size = 100
+        remote_timeout = 5
+
+        try:
+            process_limit = settings.PDK_BUNDLE_PROCESS_LIMIT
+        except AttributeError:
+            pass
+
+        try:
+            remote_bundle_size = settings.PDK_REMOTE_BUNDLE_SIZE
+        except AttributeError:
+            pass
+
+        try:
+            remote_timeout = settings.PDK_REMOTE_BUNDLE_TIMEOUT
+        except AttributeError:
+            pass
+
+        return cls(
+            supports_json=install_supports_jsonfield(),
+            default_tz=timezone.get_default_timezone(),
+            process_limit=process_limit,
+            remote_bundle_size=remote_bundle_size,
+            remote_timeout=remote_timeout,
+        )
+
+    def mark_bundle_errored(self, bundle_pk, bundle_trace_id, error_class):
+        bundle = DataBundle.objects.get(pk=bundle_pk)
+        bundle.errored = timezone.now()
+        bundle.save()
+
+        record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', error_class=error_class)
+
+    def decode_bundle_properties(self, bundle):
+        if self.supports_json is False:
+            bundle.properties = json.loads(bundle.properties)
+
+        if bundle.encrypted:
+            if 'nonce' in bundle.properties and 'encrypted' in bundle.properties:
+                payload = base64.b64decode(bundle.properties['encrypted'])
+                nonce = base64.b64decode(bundle.properties['nonce'])
+
+                if self.private_key is None:
+                    self.private_key = PrivateKey(base64.b64decode(settings.PDK_SERVER_KEY).strip()) # pylint: disable=line-too-long
+
+                if self.public_key is None:
+                    self.public_key = PublicKey(base64.b64decode(settings.PDK_CLIENT_KEY).strip()) # pylint: disable=line-too-long
+
+                box = Box(self.private_key, self.public_key)
+                decrypted_message = box.decrypt(payload, nonce)
+                decrypted = six.text_type(decrypted_message, encoding='utf8')
+
+                if bundle.compression != 'none':
+                    compressed = base64.b64decode(decrypted)
+
+                    if bundle.compression == 'gzip':
+                        fio = BytesIO(compressed)
+                        gzip_file_obj = gzip.GzipFile(fileobj=fio)
+                        payload = gzip_file_obj.read()
+                        gzip_file_obj.close()
+
+                        decrypted = payload
+
+                bundle.properties = json.loads(decrypted)
+            elif 'encrypted' in bundle.properties:
+                print('Missing "nonce" in encrypted bundle. Cannot decrypt bundle ' + str(bundle.pk) + '. Skipping...')
+                # Preserve current malformed-encrypted behavior for now: stop
+                # processing additional bundles without marking this one errored.
+                raise BundleProcessingHalt()
+            elif 'nonce' in bundle.properties:
+                print('Missing "encrypted" in encrypted bundle. Cannot decrypt bundle ' + str(bundle.pk) + '. Skipping...')
+                raise BundleProcessingHalt()
+        elif bundle.compression != 'none':
+            compressed = base64.b64decode(bundle.properties['payload'])
+
+            if bundle.compression == 'gzip':
+                fio = BytesIO(compressed)
+                gzip_file_obj = gzip.GzipFile(fileobj=fio)
+                payload = gzip_file_obj.read()
+                gzip_file_obj.close()
+
+                self.bundle_size += len(payload)
+
+                bundle.properties = json.loads(payload)
+
+        return bundle.properties
+
+    def is_ingestable_point(self, bundle_point):
+        return bundle_point is not None and 'passive-data-metadata' in bundle_point and \
+               'source' in bundle_point['passive-data-metadata'] and \
+               'generator' in bundle_point['passive-data-metadata']
+
+    def prepare_bundle_point(self, bundle_point, bundle, bundle_trace_id):
+        source = bundle_point['passive-data-metadata']['source']
+
+        if source == '':
+            source = 'missing-source'
+
+        try:
+            source = settings.PDK_RENAME_SOURCE(source)
+            bundle_point['passive-data-metadata']['source'] = source
+        except AttributeError:
+            pass
+
+        try:
+            attach_trace_context(bundle_point, bundle, bundle_trace_id)
+            settings.PDK_INSPECT_DATA_POINT_AT_INGEST(bundle_point)
+        except AttributeError:
+            pass
+
+        return bundle_point
+
+    def server_url_for_source(self, source):
+        if source in self.sources:
+            return self.sources[source]
+
+        server_url = ''
+        source_obj = DataSource.objects.filter(identifier=source).first()
+
+        if source_obj is not None:
+            if source_obj.server is not None:
+                server_url = source_obj.server.upload_url
+        else:
+            if source is not None:
+                source_obj = DataSource(name=source, identifier=source)
+                source_obj.save()
+                source_obj.join_default_group()
+
+        self.sources[source] = server_url
+
+        return server_url
+
+    def build_local_point(self, bundle_point, now, bundle):
+        point = DataPoint(recorded=now)
+        bundle_point['passive-data-metadata']['encrypted_transmission'] = bundle.encrypted
+
+        point.source = bundle_point['passive-data-metadata']['source']
+
+        if point.source is None:
+            point.source = '-'
+
+        point.generator = bundle_point['passive-data-metadata']['generator']
+
+        if 'generator-id' in bundle_point['passive-data-metadata']:
+            point.generator_identifier = bundle_point['passive-data-metadata']['generator-id']
+
+        if 'latitude' in bundle_point['passive-data-metadata'] and 'longitude' in bundle_point['passive-data-metadata']:
+            point.generated_at = GEOSGeometry('POINT(' + str(bundle_point['passive-data-metadata']['longitude']) + ' ' + str(bundle_point['passive-data-metadata']['latitude']) + ')')
+        elif 'latitude' in bundle_point and 'longitude' in bundle_point:
+            point.generated_at = GEOSGeometry('POINT(' + str(bundle_point['longitude']) + ' ' + str(bundle_point['latitude']) + ')')
+
+        point.created = datetime.datetime.fromtimestamp(bundle_point['passive-data-metadata']['timestamp'], tz=self.default_tz)
+
+        if self.supports_json:
+            point.properties = json.loads(json.dumps(bundle_point, indent=2).encode('utf-16', 'surrogatepass').decode('utf-16'))
+        else:
+            point.properties = json.dumps(bundle_point, indent=2)
+
+        point.fetch_secondary_identifier(skip_save=True, properties=bundle_point)
+        point.fetch_user_agent(skip_save=True, properties=bundle_point)
+        point.fetch_generator_definition(skip_save=True)
+        point.fetch_source_reference(skip_save=True)
+
+        return point
+
+    def queue_remote_point(self, server_url, bundle_point):
+        if (server_url in self.xmit_points) is False:
+            self.xmit_points[server_url] = []
+
+        self.xmit_points[server_url].append(bundle_point)
+
+    def record_created_point(self, point):
+        if (point.source in self.seen_sources) is False:
+            self.seen_sources.append(point.source)
+
+        if (point.source in self.source_identifiers) is False:
+            self.source_identifiers[point.source] = []
+
+        latest_key = point.source + '--' + point.generator_identifier
+
+        if (latest_key in self.latest_points) is False or self.latest_points[latest_key].created < point.created:
+            self.latest_points[latest_key] = point
+
+        if (point.generator_identifier in self.seen_generators) is False:
+            self.seen_generators.append(point.generator_identifier)
+
+        if (point.generator_identifier in self.source_identifiers[point.source]) is False:
+            self.source_identifiers[point.source].append(point.generator_identifier)
+
+    def evaluate_remote_uploads(self, bundle, bundle_trace_id):
+        if len(self.xmit_points) == 0: # pylint: disable=len-as-condition
+            return True
+
+        failed = False
+
+        for server_url, points in self.xmit_points.items():
+            if len(points) > self.remote_bundle_size:
+                payload = {
+                    'payload': json.dumps(points, indent=2)
+                }
+
+                try:
+                    bundle_post = requests.post(server_url, data=payload, timeout=self.remote_timeout)
+
+                    if bundle_post.status_code < 200 and bundle_post.status_code >= 300:
+                        failed = True
+
+                    self.xmit_points[server_url] = []
+                except requests.exceptions.Timeout:
+                    print('Unable to transmit data to ' + server_url + ' (timeout=' + str(self.remote_timeout) + ').')
+                    failed = True
+
+        if failed is False:
+            return True
+
+        logging.critical(
+            'Error encountered uploading contents of trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
+            *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
+        )
+        record_bundle_processing_trace(bundle, bundle_trace_id, 'upload_failed', properties=bundle.properties)
+
+        return False
+
+    def process_bundle(self, bundle, bundle_trace_id, bad_payload_handler): # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        original_properties = bundle.properties
+        bundle_files = bundle.data_files.all()
+        has_bundles = (bundle_files.count() > 0)
+
+        bundle.properties = self.decode_bundle_properties(bundle)
+
+        logging.info(
+            'Processing bundle trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
+            *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
+        )
+        record_bundle_processing_trace(bundle, bundle_trace_id, 'started', properties=bundle.properties)
+
+        now = timezone.now()
+        to_record = []
+
+        for bundle_point in bundle.properties:
+            try:
+                bundle_point = bad_payload_handler(bundle_point, bundle)
+            except StopProcessingCurrentBundle:
+                break
+
+            try:
+                if self.is_ingestable_point(bundle_point):
+                    bundle_point = self.prepare_bundle_point(bundle_point, bundle, bundle_trace_id)
+                    server_url = self.server_url_for_source(bundle_point['passive-data-metadata']['source'])
+
+                    if server_url == '':
+                        point = self.build_local_point(bundle_point, now, bundle)
+                        to_record.append(point)
+                    else:
+                        self.queue_remote_point(server_url, bundle_point)
+
+                    self.new_point_count += 1
+            except DataError:
+                traceback.print_exc()
+                logging.debug('Error ingesting bundle: %s:', bundle.pk)
+                logging.debug(str(bundle.properties))
+                logging.critical(
+                    'Error ingesting bundle trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
+                    *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
+                )
+                record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', properties=bundle.properties, error_class='DataError')
+
+        return BundleProcessResult(
+            original_properties=original_properties,
+            bundle_files=bundle_files,
+            has_bundles=has_bundles,
+            to_record=to_record,
+            mark_processed=self.evaluate_remote_uploads(bundle, bundle_trace_id),
+        )
+
+    def flush_remote_points(self):
+        for server_url, points in self.xmit_points.items():
+            if points:
+                payload = {
+                    'payload': json.dumps(points, indent=2)
+                }
+
+                try:
+                    bundle_post = requests.post(server_url, data=payload, timeout=self.remote_timeout)
+
+                    if bundle_post.status_code < 200 and bundle_post.status_code >= 300:
+                        failed = True # pylint: disable=unused-variable
+
+                    self.xmit_points[server_url] = []
+                except requests.exceptions.Timeout:
+                    print('Unable to transmit data to ' + server_url + ' (timeout=' + str(self.remote_timeout) + ').')
+
+    def delete_processed_bundles(self):
+        for bundle in self.to_delete:
+            bundle.delete()
+
+    def update_stats(self):
+        data_point_count = DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).first()
+
+        if data_point_count is None:
+            count = DataPoint.objects.all().count()
+            data_point_count = DataServerMetadatum(key=TOTAL_DATA_POINT_COUNT_DATUM)
+            data_point_count.value = str(count)
+            data_point_count.save()
+        else:
+            count = int(data_point_count.value)
+            count += self.new_point_count
+            data_point_count.value = str(count)
+            data_point_count.save()
+
+        sources = DataServerMetadatum.objects.filter(key=SOURCES_DATUM).first()
+
+        if sources is not None:
+            updated = False
+            source_list = json.loads(sources.value)
+
+            for seen_source in self.seen_sources:
+                if (seen_source in source_list) is False:
+                    source_list.append(seen_source)
+                    updated = True
+
+            if updated:
+                sources.value = json.dumps(source_list, indent=2)
+                sources.save()
+        else:
+            DataPoint.objects.sources()
+
+        for source, identifiers in list(self.source_identifiers.items()):
+            datum_key = SOURCE_GENERATORS_DATUM + ': ' + source
+            source_id_datum = DataServerMetadatum.objects.filter(key=datum_key).first()
+
+            source_ids = []
+
+            if source_id_datum is not None:
+                source_ids = json.loads(source_id_datum.value)
+            else:
+                source_id_datum = DataServerMetadatum(key=datum_key)
+
+            updated = False
+
+            for identifier in identifiers:
+                if (identifier in source_ids) is False:
+                    source_ids.append(identifier)
+                    updated = True
+
+            if updated:
+                source_id_datum.value = json.dumps(source_ids, indent=2)
+                source_id_datum.save()
+
+        generators_datum = DataServerMetadatum.objects.filter(key=SOURCE_GENERATORS_DATUM).first()
+
+        generator_ids = []
+
+        if generators_datum is not None:
+            generator_ids = json.loads(generators_datum.value)
+        else:
+            generators_datum = DataServerMetadatum(key=SOURCE_GENERATORS_DATUM)
+
+        updated = False
+
+        for identifier in self.seen_generators:
+            if (identifier in generator_ids) is False:
+                generator_ids.append(identifier)
+                updated = True
+
+        if updated:
+            generators_datum.value = json.dumps(generator_ids, indent=2)
+            generators_datum.save()
+
+        for latest_key, point in list(self.latest_points.items()):
+            datum_key = 'latest_point--' + latest_key
+            latest_datum = DataServerMetadatum.objects.filter(key=datum_key).first()
+
+            if latest_datum is None:
+                latest_datum = DataServerMetadatum(key=datum_key)
+
+            latest_datum.value = str(point.pk)
+            latest_datum.save()

--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -12,7 +12,6 @@ import logging
 import traceback
 import uuid
 
-from dataclasses import dataclass
 from io import BytesIO
 
 import requests
@@ -135,13 +134,13 @@ class StopProcessingCurrentBundle(Exception):
     pass
 
 
-@dataclass
 class BundleProcessResult:
-    original_properties: object
-    bundle_files: object
-    has_bundles: bool
-    to_record: list
-    mark_processed: bool
+    def __init__(self, original_properties, bundle_files, has_bundles, to_record, mark_processed):
+        self.original_properties = original_properties
+        self.bundle_files = bundle_files
+        self.has_bundles = has_bundles
+        self.to_record = to_record
+        self.mark_processed = mark_processed
 
 
 class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attributes,useless-object-inheritance

--- a/db_locks.py
+++ b/db_locks.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import struct
 import time
 import traceback
 from functools import wraps
@@ -11,15 +12,12 @@ BUNDLE_PROCESSING_LOCK_NAME = 'passive_data_kit.DataBundle.DataPoint.bundle_proc
 
 
 def _lock_key(lock_name):
-    digest = hashlib.blake2s(
+    digest = hashlib.blake2s(  # pylint: disable=no-member
         lock_name.encode('utf-8'),
         digest_size=8,
     ).digest()
 
-    return (
-        int.from_bytes(digest[:4], byteorder='big', signed=True),
-        int.from_bytes(digest[4:], byteorder='big', signed=True),
-    )
+    return struct.unpack('>ii', digest[:8])
 
 
 def _ensure_postgresql():
@@ -47,7 +45,7 @@ def _release(lock_name):
         return bool(cursor.fetchone()[0])
 
 
-def is_bundle_processing_lock_active():
+def is_bundle_processing_lock_active():  # pylint: disable=invalid-name
     acquired = _try_acquire(BUNDLE_PROCESSING_LOCK_NAME)
 
     if acquired:
@@ -61,6 +59,7 @@ def handle_bundle_processing_lock(handle):
     @wraps(handle)
     def wrapper(self, *args, **options):
         start_time = time.time()
+        result = None
         verbosity = options.get('verbosity', 0)
 
         if verbosity == 0:
@@ -77,13 +76,16 @@ def handle_bundle_processing_lock(handle):
         logging.debug('%s: Acquiring DB advisory lock...', BUNDLE_PROCESSING_LOCK_NAME)
 
         if _try_acquire(BUNDLE_PROCESSING_LOCK_NAME) is False:
-            logging.debug('%s: DB advisory lock already in place. Quitting.', BUNDLE_PROCESSING_LOCK_NAME)
-            return
+            logging.debug(
+                '%s: DB advisory lock already in place. Quitting.',
+                BUNDLE_PROCESSING_LOCK_NAME,
+            )
+            return None
 
         logging.debug('%s: DB advisory lock acquired.', BUNDLE_PROCESSING_LOCK_NAME)
 
         try:
-            return handle(self, *args, **options)
+            result = handle(self, *args, **options)
         except: # pylint: disable=bare-except
             logging.error('%s: Command Failed', BUNDLE_PROCESSING_LOCK_NAME)
             logging.error('==' * 72)
@@ -94,8 +96,17 @@ def handle_bundle_processing_lock(handle):
                 _release(BUNDLE_PROCESSING_LOCK_NAME)
                 logging.debug('%s: DB advisory lock released.', BUNDLE_PROCESSING_LOCK_NAME)
             except Exception: # pylint: disable=broad-except
-                logging.exception('%s: Failed to release DB advisory lock cleanly.', BUNDLE_PROCESSING_LOCK_NAME)
+                logging.exception(
+                    '%s: Failed to release DB advisory lock cleanly.',
+                    BUNDLE_PROCESSING_LOCK_NAME,
+                )
 
-            logging.debug('%s: Done in %.2f seconds', BUNDLE_PROCESSING_LOCK_NAME, (time.time() - start_time))
+            logging.debug(
+                '%s: Done in %.2f seconds',
+                BUNDLE_PROCESSING_LOCK_NAME,
+                (time.time() - start_time),
+            )
+
+        return result
 
     return wrapper

--- a/db_locks.py
+++ b/db_locks.py
@@ -1,0 +1,101 @@
+import hashlib
+import logging
+import time
+import traceback
+from functools import wraps
+
+from django.db import connection
+
+
+BUNDLE_PROCESSING_LOCK_NAME = 'passive_data_kit.DataBundle.DataPoint.bundle_processing.v1'
+
+
+def _lock_key(lock_name):
+    digest = hashlib.blake2s(
+        lock_name.encode('utf-8'),
+        digest_size=8,
+    ).digest()
+
+    return (
+        int.from_bytes(digest[:4], byteorder='big', signed=True),
+        int.from_bytes(digest[4:], byteorder='big', signed=True),
+    )
+
+
+def _ensure_postgresql():
+    if connection.vendor != 'postgresql':
+        raise RuntimeError('Bundle-processing DB advisory locks require PostgreSQL.')
+
+
+def _try_acquire(lock_name):
+    _ensure_postgresql()
+    connection.ensure_connection()
+    key_one, key_two = _lock_key(lock_name)
+
+    with connection.cursor() as cursor:
+        cursor.execute('SELECT pg_try_advisory_lock(%s, %s)', [key_one, key_two])
+        return bool(cursor.fetchone()[0])
+
+
+def _release(lock_name):
+    _ensure_postgresql()
+    connection.ensure_connection()
+    key_one, key_two = _lock_key(lock_name)
+
+    with connection.cursor() as cursor:
+        cursor.execute('SELECT pg_advisory_unlock(%s, %s)', [key_one, key_two])
+        return bool(cursor.fetchone()[0])
+
+
+def is_bundle_processing_lock_active():
+    acquired = _try_acquire(BUNDLE_PROCESSING_LOCK_NAME)
+
+    if acquired:
+        _release(BUNDLE_PROCESSING_LOCK_NAME)
+        return False
+
+    return True
+
+
+def handle_bundle_processing_lock(handle):
+    @wraps(handle)
+    def wrapper(self, *args, **options):
+        start_time = time.time()
+        verbosity = options.get('verbosity', 0)
+
+        if verbosity == 0:
+            level = logging.ERROR
+        elif verbosity == 1:
+            level = logging.WARN
+        elif verbosity == 2:
+            level = logging.INFO
+        else:
+            level = logging.DEBUG
+
+        logging.basicConfig(level=level, format='%(message)s')
+        logging.debug('-' * 72)
+        logging.debug('%s: Acquiring DB advisory lock...', BUNDLE_PROCESSING_LOCK_NAME)
+
+        if _try_acquire(BUNDLE_PROCESSING_LOCK_NAME) is False:
+            logging.debug('%s: DB advisory lock already in place. Quitting.', BUNDLE_PROCESSING_LOCK_NAME)
+            return
+
+        logging.debug('%s: DB advisory lock acquired.', BUNDLE_PROCESSING_LOCK_NAME)
+
+        try:
+            return handle(self, *args, **options)
+        except: # pylint: disable=bare-except
+            logging.error('%s: Command Failed', BUNDLE_PROCESSING_LOCK_NAME)
+            logging.error('==' * 72)
+            logging.error(traceback.format_exc())
+            logging.error('==' * 72)
+        finally:
+            try:
+                _release(BUNDLE_PROCESSING_LOCK_NAME)
+                logging.debug('%s: DB advisory lock released.', BUNDLE_PROCESSING_LOCK_NAME)
+            except Exception: # pylint: disable=broad-except
+                logging.exception('%s: Failed to release DB advisory lock cleanly.', BUNDLE_PROCESSING_LOCK_NAME)
+
+            logging.debug('%s: Done in %.2f seconds', BUNDLE_PROCESSING_LOCK_NAME, (time.time() - start_time))
+
+    return wrapper

--- a/management/commands/pdk_process_bundles.py
+++ b/management/commands/pdk_process_bundles.py
@@ -4,34 +4,44 @@ from __future__ import print_function
 
 from builtins import str # pylint: disable=redefined-builtin
 
-import base64
-import datetime
-import gzip
 import json
 import logging
-import traceback
 
-from io import BytesIO
-
-import requests
-import six
-
-from nacl.public import PublicKey, PrivateKey, Box
-
-from django.conf import settings
-from django.contrib.gis.geos import GEOSGeometry
 from django.core.management.base import BaseCommand
-from django.db import transaction, DataError
+from django.db import transaction
 from django.db.transaction import TransactionManagementError
 from django.utils import timezone
 
 from ...decorators import handle_lock, log_scheduled_event
-from ...bundle_processing import attach_trace_context, bundle_log_fields, \
+from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
                                  new_bundle_trace_id, record_bundle_deleted, \
                                  record_bundle_processing_trace
-from ...models import DataServerMetadatum, DataPoint, DataBundle, DataSource, \
-                      install_supports_jsonfield, TOTAL_DATA_POINT_COUNT_DATUM, \
-                      SOURCES_DATUM, SOURCE_GENERATORS_DATUM
+from ...models import DataBundle, DataPoint, DataServerMetadatum, TOTAL_DATA_POINT_COUNT_DATUM
+
+
+def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
+    if bundle_point is not None:
+        point_json = json.dumps(bundle_point)
+
+        while r'\u0000' in point_json:
+            print('Detected 0x00 byte in ' + str(bundle.pk) + '. Stripping and ingesting...')
+            point_json = point_json.replace(r'\u0000', '')
+
+        bundle_point = json.loads(point_json)
+
+    return bundle_point
+
+
+def save_serial_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
+    points = DataPoint.objects.bulk_create(to_record)
+
+    for point in points:
+        record_bundle_processing_trace(bundle, bundle_trace_id, 'data_point_created', data_point_id=point.pk)
+
+        if has_bundles:
+            point.fetch_bundle_files(bundle_files)
+
+    return points
 
 
 class Command(BaseCommand):
@@ -58,469 +68,63 @@ class Command(BaseCommand):
 
     @handle_lock
     @log_scheduled_event
-    def handle(self, *args, **options): # pylint: disable=too-many-locals, too-many-branches, too-many-statements
-        to_delete = []
+    def handle(self, *args, **options):
+        core = BundleProcessingCore.from_settings()
+        bundles = DataBundle.objects.filter(processed=False, errored=None)[:options['bundle_count']]
 
-        supports_json = install_supports_jsonfield()
+        for bundle in bundles:
+            if core.new_point_count >= core.process_limit:
+                break
 
-        default_tz = timezone.get_default_timezone()
+            core.processed_bundle_count += 1
+            bundle_trace_id = new_bundle_trace_id()
 
-        seen_sources = []
-        seen_generators = []
-        source_identifiers = {}
+            try:
+                with transaction.atomic():
+                    result = core.process_bundle(bundle, bundle_trace_id, strip_null_bytes_bad_payload_handler)
 
-        latest_points = {}
-
-        new_point_count = 0
-        processed_bundle_count = 0
-        process_limit = 1000
-        remote_bundle_size = 100
-        remote_timeout = 5
-
-        try:
-            process_limit = settings.PDK_BUNDLE_PROCESS_LIMIT
-        except AttributeError:
-            pass
-
-        try:
-            remote_bundle_size = settings.PDK_REMOTE_BUNDLE_SIZE
-        except AttributeError:
-            pass
-
-        try:
-            remote_timeout = settings.PDK_REMOTE_BUNDLE_TIMEOUT
-        except AttributeError:
-            pass
-
-        sources = {}
-
-        private_key = None
-        public_key = None
-
-        xmit_points = {}
-
-        start_processing = timezone.now()
-
-        bundle_size = 0
-
-        for bundle in DataBundle.objects.filter(processed=False, errored=None)[:options['bundle_count']]: # pylint: disable=too-many-nested-blocks
-            if new_point_count < process_limit:
-                processed_bundle_count += 1
-
-                original_properties = bundle.properties
-                bundle_trace_id = new_bundle_trace_id()
-
-                bundle_files = bundle.data_files.all()
-
-                has_bundles = (bundle_files.count() > 0)
-
-                try:
-                    with transaction.atomic():
-                        if supports_json is False:
-                            bundle.properties = json.loads(bundle.properties)
-
-                        if bundle.encrypted:
-                            if 'nonce' in bundle.properties and 'encrypted' in bundle.properties:
-                                payload = base64.b64decode(bundle.properties['encrypted'])
-                                nonce = base64.b64decode(bundle.properties['nonce'])
-
-                                if private_key is None:
-                                    private_key = PrivateKey(base64.b64decode(settings.PDK_SERVER_KEY).strip()) # pylint: disable=line-too-long
-
-                                if public_key is None:
-                                    public_key = PublicKey(base64.b64decode(settings.PDK_CLIENT_KEY).strip()) # pylint: disable=line-too-long
-
-                                box = Box(private_key, public_key)
-
-                                decrypted_message = box.decrypt(payload, nonce)
-
-                                decrypted = six.text_type(decrypted_message, encoding='utf8')
-
-                                if bundle.compression != 'none':
-                                    compressed = base64.b64decode(decrypted)
-
-                                    if bundle.compression == 'gzip':
-                                        fio = BytesIO(compressed)  # io.BytesIO for Python 3
-                                        gzip_file_obj = gzip.GzipFile(fileobj=fio)
-                                        payload = gzip_file_obj.read()
-                                        gzip_file_obj.close()
-
-                                        decrypted = payload
-
-                                bundle.properties = json.loads(decrypted)
-                            elif 'encrypted' in bundle.properties:
-                                print('Missing "nonce" in encrypted bundle. Cannot decrypt bundle ' + str(bundle.pk) + '. Skipping...')
-                                break
-                            elif 'nonce' in bundle.properties:
-                                print('Missing "encrypted" in encrypted bundle. Cannot decrypt bundle ' + str(bundle.pk) + '. Skipping...')
-                                break
-                        elif bundle.compression != 'none':
-                            compressed = base64.b64decode(bundle.properties['payload'])
-
-                            if bundle.compression == 'gzip':
-                                fio = BytesIO(compressed)  # io.BytesIO for Python 3
-                                gzip_file_obj = gzip.GzipFile(fileobj=fio)
-                                payload = gzip_file_obj.read()
-                                gzip_file_obj.close()
-
-                                bundle_size += len(payload)
-
-                                bundle.properties = json.loads(payload)
-
-                                # print(' Compress: %d -- %s' % (bundle.pk, timezone.now()))
-
-                        logging.info(
-                            'Processing bundle trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
-                            *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
+                    if len(result.to_record) > 0: # pylint: disable=len-as-condition
+                        points = save_serial_points(
+                            result.to_record,
+                            result.has_bundles,
+                            result.bundle_files,
+                            bundle,
+                            bundle_trace_id,
                         )
-                        record_bundle_processing_trace(bundle, bundle_trace_id, 'started', properties=bundle.properties)
 
-                        now = timezone.now()
+                        for point in points:
+                            core.record_created_point(point)
 
-                        to_record = []
+                    if result.mark_processed:
+                        bundle.processed = True
+                        record_bundle_processing_trace(bundle, bundle_trace_id, 'processed', properties=bundle.properties)
 
-                        for bundle_point in bundle.properties: # pylint: disable=too-many-nested-blocks
-                            # logging.debug('POINT: %s', json.dumps(bundle_point, indent=2))
-
-                            if bundle_point is not None:
-                                point_json = json.dumps(bundle_point)
-
-                                while r'\u0000' in point_json:
-                                    print('Detected 0x00 byte in ' + str(bundle.pk) + '. Stripping and ingesting...')
-
-                                    point_json = point_json.replace(r'\u0000', '')
-
-                                # while r'\ud83c' in point_json:
-                                #    print('Detected 0xd83c byte in ' + str(bundle.pk) + '. Stripping and ingesting...')
-
-                                #    point_json = point_json.replace(r'\ud83c', '')
-
-                                bundle_point = json.loads(point_json)
-
-                            try:
-                                if bundle_point is not None and 'passive-data-metadata' in bundle_point and 'source' in bundle_point['passive-data-metadata'] and 'generator' in bundle_point['passive-data-metadata']:
-                                    source = bundle_point['passive-data-metadata']['source']
-
-                                    if source == '':
-                                        source = 'missing-source'
-
-                                    try:
-                                        source = settings.PDK_RENAME_SOURCE(source)
-
-                                        bundle_point['passive-data-metadata']['source'] = source
-                                    except AttributeError:
-                                        pass # Optional method not defined
-
-                                    try:
-                                        attach_trace_context(bundle_point, bundle, bundle_trace_id)
-                                        settings.PDK_INSPECT_DATA_POINT_AT_INGEST(bundle_point)
-                                    except AttributeError:
-                                        pass # Optional method not defined
-
-                                    server_url = None
-
-                                    if source in sources:
-                                        server_url = sources[source]
-                                    else:
-                                        source_obj = DataSource.objects.filter(identifier=source).first()
-
-                                        if source_obj is not None:
-                                            if source_obj.server is not None:
-                                                server_url = source_obj.server.upload_url
-                                        else:
-                                            if source is not None:
-                                                source_obj = DataSource(name=source, identifier=source)
-                                                source_obj.save()
-
-                                                source_obj.join_default_group()
-
-                                        if server_url is None:
-                                            server_url = ''
-
-                                        sources[source] = server_url
-
-                                    if server_url == '':
-                                        point = DataPoint(recorded=now)
-                                        bundle_point['passive-data-metadata']['encrypted_transmission'] = bundle.encrypted
-
-                                        point.source = bundle_point['passive-data-metadata']['source']
-
-                                        if point.source is None:
-                                            point.source = '-'
-
-                                        point.generator = bundle_point['passive-data-metadata']['generator']
-
-                                        if 'generator-id' in bundle_point['passive-data-metadata']:
-                                            point.generator_identifier = bundle_point['passive-data-metadata']['generator-id']
-
-                                        if 'latitude' in bundle_point['passive-data-metadata'] and 'longitude' in bundle_point['passive-data-metadata']:
-                                            point.generated_at = GEOSGeometry('POINT(' + str(bundle_point['passive-data-metadata']['longitude']) + ' ' + str(bundle_point['passive-data-metadata']['latitude']) + ')')
-                                        elif 'latitude' in bundle_point and 'longitude' in bundle_point:
-                                            point.generated_at = GEOSGeometry('POINT(' + str(bundle_point['longitude']) + ' ' + str(bundle_point['latitude']) + ')')
-
-                                        point.created = datetime.datetime.fromtimestamp(bundle_point['passive-data-metadata']['timestamp'], tz=default_tz)
-
-                                        if supports_json:
-                                            point.properties = json.loads(json.dumps(bundle_point, indent=2).encode('utf-16', 'surrogatepass').decode('utf-16'))
-                                        else:
-                                            point.properties = json.dumps(bundle_point, indent=2)
-
-                                        point.fetch_secondary_identifier(skip_save=True, properties=bundle_point)
-                                        point.fetch_user_agent(skip_save=True, properties=bundle_point)
-                                        point.fetch_generator_definition(skip_save=True)
-                                        point.fetch_source_reference(skip_save=True)
-
-                                        to_record.append(point)
-
-#                                        point.save()
-#
-#                                        if has_bundles:
-#                                            point.fetch_bundle_files(bundle_files)
-#
-#                                        if (point.source in seen_sources) is False:
-#                                            seen_sources.append(point.source)
-#
-#                                        if (point.source in source_identifiers) is False:
-#                                            source_identifiers[point.source] = []
-#
-#                                        latest_key = point.source + '--' + point.generator_identifier
-#
-#                                        if (latest_key in latest_points) is False or latest_points[latest_key].created < point.created:
-#                                            latest_points[latest_key] = point
-#
-#                                        if (point.generator_identifier in seen_generators) is False:
-#                                            seen_generators.append(point.generator_identifier)
-#
-#                                        if (point.generator_identifier in source_identifiers[point.source]) is False:
-#                                            source_identifiers[point.source].append(point.generator_identifier)
-                                    else:
-                                        if (server_url in xmit_points) is False:
-                                            xmit_points[server_url] = []
-
-                                        xmit_points[server_url].append(bundle_point)
-
-                                    new_point_count += 1
-                            except DataError:
-                                traceback.print_exc()
-                                logging.debug('Error ingesting bundle: %s:', bundle.pk)
-                                logging.debug(str(bundle.properties))
-                                logging.critical(
-                                    'Error ingesting bundle trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
-                                    *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
-                                )
-                                record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', properties=bundle.properties, error_class='DataError')
-
-                        if len(to_record) > 0: # pylint: disable=len-as-condition
-                            points = DataPoint.objects.bulk_create(to_record)
-
-                            for point in points:
-                                record_bundle_processing_trace(bundle, bundle_trace_id, 'data_point_created', data_point_id=point.pk)
-
-                                if has_bundles:
-                                    point.fetch_bundle_files(bundle_files)
-
-                                if (point.source in seen_sources) is False:
-                                    seen_sources.append(point.source)
-
-                                if (point.source in source_identifiers) is False:
-                                    source_identifiers[point.source] = []
-
-                                latest_key = point.source + '--' + point.generator_identifier
-
-                                if (latest_key in latest_points) is False or latest_points[latest_key].created < point.created:
-                                    latest_points[latest_key] = point
-
-                                if (point.generator_identifier in seen_generators) is False:
-                                    seen_generators.append(point.generator_identifier)
-
-                                if (point.generator_identifier in source_identifiers[point.source]) is False:
-                                    source_identifiers[point.source].append(point.generator_identifier)
-
-                        if len(xmit_points) == 0: # pylint: disable=len-as-condition
-                            bundle.processed = True
-                            record_bundle_processing_trace(bundle, bundle_trace_id, 'processed', properties=bundle.properties)
-                        else:
-                            failed = False
-
-                            for server_url, points in xmit_points.items():
-                                if len(points) > remote_bundle_size:
-                                    payload = {
-                                        'payload': json.dumps(points, indent=2)
-                                    }
-
-                                    try:
-                                        bundle_post = requests.post(server_url, data=payload, timeout=remote_timeout)
-
-                                        if bundle_post.status_code < 200 and bundle_post.status_code >= 300:
-                                            failed = True
-
-                                        # print(server_url + ': ' + str(len(points)))
-
-                                        xmit_points[server_url] = []
-                                    except requests.exceptions.Timeout:
-                                        print('Unable to transmit data to ' + server_url + ' (timeout=' + str(remote_timeout) + ').')
-
-                                        failed = True
-
-                            if failed is False:
-                                bundle.processed = True
-                                record_bundle_processing_trace(bundle, bundle_trace_id, 'processed', properties=bundle.properties)
-                            else:
-                                logging.critical(
-                                    'Error encountered uploading contents of trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
-                                    *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
-                                )
-                                record_bundle_processing_trace(bundle, bundle_trace_id, 'upload_failed', properties=bundle.properties)
-
-                        bundle.properties = original_properties
-
-                        bundle.save()
-
-                        if options['delete']:
-                            record_bundle_deleted(bundle, bundle_trace_id)
-                            to_delete.append(bundle)
-
-                except TransactionManagementError:
-                    print('[TransactionManagementError] Abandoning and marking errored ' + str(bundle.pk) + '.')
-
-                    bundle = DataBundle.objects.get(pk=bundle.pk)
-
-                    bundle.errored = timezone.now()
+                    bundle.properties = result.original_properties
                     bundle.save()
-                    record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', error_class='TransactionManagementError')
 
-                except TypeError:
-                    print('[TypeError] Abandoning and marking errored ' + str(bundle.pk) + '.')
+                    if options['delete']:
+                        record_bundle_deleted(bundle, bundle_trace_id)
+                        core.to_delete.append(bundle)
+            except BundleProcessingHalt:
+                break
+            except TransactionManagementError:
+                print('[TransactionManagementError] Abandoning and marking errored ' + str(bundle.pk) + '.')
+                core.mark_bundle_errored(bundle.pk, bundle_trace_id, 'TransactionManagementError')
+            except TypeError:
+                print('[TypeError] Abandoning and marking errored ' + str(bundle.pk) + '.')
+                core.mark_bundle_errored(bundle.pk, bundle_trace_id, 'TypeError')
 
-                    bundle = DataBundle.objects.get(pk=bundle.pk)
+        elapsed = (timezone.now() - core.start_processing).total_seconds()
 
-                    bundle.errored = timezone.now()
-                    bundle.save()
-                    record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', error_class='TypeError')
-
-        end_processing = timezone.now()
-
-        elapsed = (end_processing - start_processing).total_seconds()
-
-        if processed_bundle_count > 0:
-            logging.debug('PROCESSED: %d -- %.3f -- %.3f (%s / %s)', processed_bundle_count, elapsed, (elapsed / processed_bundle_count), new_point_count, bundle_size)
+        if core.processed_bundle_count > 0:
+            logging.debug('PROCESSED: %d -- %.3f -- %.3f (%s / %s)', core.processed_bundle_count, elapsed, (elapsed / core.processed_bundle_count), core.new_point_count, core.bundle_size)
         else:
-            logging.debug('PROCESSED: %d -- %.3f -- %.3f (%s / %s)', processed_bundle_count, elapsed, 0, new_point_count, bundle_size)
+            logging.debug('PROCESSED: %d -- %.3f -- %.3f (%s / %s)', core.processed_bundle_count, elapsed, 0, core.new_point_count, core.bundle_size)
 
-        for server_url, points in xmit_points.items():
-            if points:
-                payload = {
-                    'payload': json.dumps(points, indent=2)
-                }
-
-                try:
-                    bundle_post = requests.post(server_url, data=payload, timeout=remote_timeout)
-
-                    if bundle_post.status_code < 200 and bundle_post.status_code >= 300:
-                        failed = True
-
-                    # print(server_url + ': ' + str(len(points)))
-
-                    xmit_points[server_url] = []
-                except requests.exceptions.Timeout:
-                    print('Unable to transmit data to ' + server_url + ' (timeout=' + str(remote_timeout) + ').')
-
-        for bundle in to_delete:
-            bundle.delete()
+        core.flush_remote_points()
+        core.delete_processed_bundles()
 
         if options['skip_stats'] is False:
-            data_point_count = DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).first()
-
-            if data_point_count is None:
-                count = DataPoint.objects.all().count()
-
-                data_point_count = DataServerMetadatum(key=TOTAL_DATA_POINT_COUNT_DATUM)
-
-                data_point_count.value = str(count)
-                data_point_count.save()
-            else:
-                count = int(data_point_count.value)
-
-                count += new_point_count
-
-                data_point_count.value = str(count)
-                data_point_count.save()
-
-            data_point_count = DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).first()
-
-            sources = DataServerMetadatum.objects.filter(key=SOURCES_DATUM).first()
-
-            if sources is not None:
-                updated = False
-
-                source_list = json.loads(sources.value)
-
-                for seen_source in seen_sources:
-                    if (seen_source in source_list) is False:
-                        source_list.append(seen_source)
-
-                        updated = True
-
-                if updated:
-                    sources.value = json.dumps(source_list, indent=2)
-                    sources.save()
-            else:
-                DataPoint.objects.sources()
-
-            for source, identifiers in list(source_identifiers.items()):
-                datum_key = SOURCE_GENERATORS_DATUM + ': ' + source
-                source_id_datum = DataServerMetadatum.objects.filter(key=datum_key).first()
-
-                source_ids = []
-
-                if source_id_datum is not None:
-                    source_ids = json.loads(source_id_datum.value)
-                else:
-                    source_id_datum = DataServerMetadatum(key=datum_key)
-
-                updated = False
-
-                for identifier in identifiers:
-                    if (identifier in source_ids) is False:
-                        source_ids.append(identifier)
-
-                        updated = True
-
-                if updated:
-                    source_id_datum.value = json.dumps(source_ids, indent=2)
-                    source_id_datum.save()
-
-            datum_key = SOURCE_GENERATORS_DATUM
-            generators_datum = DataServerMetadatum.objects.filter(key=datum_key).first()
-
-            generator_ids = []
-
-            if generators_datum is not None:
-                generator_ids = json.loads(generators_datum.value)
-            else:
-                generators_datum = DataServerMetadatum(key=datum_key)
-
-            updated = False
-
-            for identifier in seen_generators:
-                if (identifier in generator_ids) is False:
-                    generator_ids.append(identifier)
-
-                    updated = True
-
-            if updated:
-                generators_datum.value = json.dumps(generator_ids, indent=2)
-                generators_datum.save()
-
-            for identifier, point in list(latest_points.items()):
-                DataPoint.objects.set_latest_point(point.source, point.generator_identifier, point)
-                DataPoint.objects.set_latest_point(point.source, 'pdk-data-frequency', point)
-
-            logging.debug("%d unprocessed payloads remaining.", DataBundle.objects.filter(processed=False, errored=None).count())
-
+            core.update_stats()
         else:
             DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).delete()
-
-        # elapsed = timezone.now() - start_time
-
-        # print('Elapsed: ' + str(elapsed) + ' -- ' + str(processed_bundle_count) + ' bundles')

--- a/management/commands/pdk_process_bundles.py
+++ b/management/commands/pdk_process_bundles.py
@@ -3,8 +3,6 @@
 from __future__ import print_function
 
 from builtins import str # pylint: disable=redefined-builtin
-
-import json
 import logging
 
 from django.core.management.base import BaseCommand
@@ -15,21 +13,11 @@ from django.utils import timezone
 from ...decorators import handle_lock, log_scheduled_event
 from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
                                  new_bundle_trace_id, record_bundle_deleted, \
-                                 record_bundle_processing_trace, save_serial_points
+                                 record_bundle_processing_trace, save_serial_points, \
+                                 strip_null_bytes_bad_payload_handler
 from ...models import DataBundle, DataServerMetadatum, TOTAL_DATA_POINT_COUNT_DATUM
 
 
-def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
-    if bundle_point is not None:
-        point_json = json.dumps(bundle_point)
-
-        while r'\u0000' in point_json:
-            print('Detected 0x00 byte in ' + str(bundle.pk) + '. Stripping and ingesting...')
-            point_json = point_json.replace(r'\u0000', '')
-
-        bundle_point = json.loads(point_json)
-
-    return bundle_point
 class Command(BaseCommand):
     help = 'Convert unprocessed DataBundle instances into DataPoint instances.'
 

--- a/management/commands/pdk_process_bundles.py
+++ b/management/commands/pdk_process_bundles.py
@@ -15,8 +15,8 @@ from django.utils import timezone
 from ...decorators import handle_lock, log_scheduled_event
 from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
                                  new_bundle_trace_id, record_bundle_deleted, \
-                                 record_bundle_processing_trace
-from ...models import DataBundle, DataPoint, DataServerMetadatum, TOTAL_DATA_POINT_COUNT_DATUM
+                                 record_bundle_processing_trace, save_serial_points
+from ...models import DataBundle, DataServerMetadatum, TOTAL_DATA_POINT_COUNT_DATUM
 
 
 def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
@@ -30,20 +30,6 @@ def strip_null_bytes_bad_payload_handler(bundle_point, bundle):
         bundle_point = json.loads(point_json)
 
     return bundle_point
-
-
-def save_serial_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
-    points = DataPoint.objects.bulk_create(to_record)
-
-    for point in points:
-        record_bundle_processing_trace(bundle, bundle_trace_id, 'data_point_created', data_point_id=point.pk)
-
-        if has_bundles:
-            point.fetch_bundle_files(bundle_files)
-
-    return points
-
-
 class Command(BaseCommand):
     help = 'Convert unprocessed DataBundle instances into DataPoint instances.'
 

--- a/management/commands/pdk_process_bundles.py
+++ b/management/commands/pdk_process_bundles.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
     @handle_bundle_processing_lock
     @log_scheduled_event
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # pylint: disable=too-many-branches
         core = BundleProcessingCore.from_settings()
         bundles = DataBundle.objects.filter(processed=False, errored=None)[:options['bundle_count']]
 

--- a/management/commands/pdk_process_bundles.py
+++ b/management/commands/pdk_process_bundles.py
@@ -10,7 +10,8 @@ from django.db import transaction
 from django.db.transaction import TransactionManagementError
 from django.utils import timezone
 
-from ...decorators import handle_lock, log_scheduled_event
+from ...db_locks import handle_bundle_processing_lock
+from ...decorators import log_scheduled_event
 from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
                                  new_bundle_trace_id, record_bundle_deleted, \
                                  record_bundle_processing_trace, save_serial_points, \
@@ -40,7 +41,7 @@ class Command(BaseCommand):
                             default=False,
                             help='Skips statistic updates for improved speeds')
 
-    @handle_lock
+    @handle_bundle_processing_lock
     @log_scheduled_event
     def handle(self, *args, **options):
         core = BundleProcessingCore.from_settings()

--- a/management/commands/pdk_process_bundles_multiprocessing.py
+++ b/management/commands/pdk_process_bundles_multiprocessing.py
@@ -4,37 +4,25 @@ from __future__ import print_function
 
 from builtins import str # pylint: disable=redefined-builtin
 
-import base64
-import datetime
 import gzip
 import json
 import logging
 import traceback
 
-from io import BytesIO
-
 from multiprocessing.pool import ThreadPool
 
 import humanize
-import requests
-import six
 
-from nacl.public import PublicKey, PrivateKey, Box
-
-from django.conf import settings
-from django.contrib.gis.geos import GEOSGeometry
 from django.core.management.base import BaseCommand
 from django.db import DataError
 from django.db.transaction import TransactionManagementError
 from django.utils import timezone
 
 from ...decorators import handle_lock, log_scheduled_event
-from ...bundle_processing import attach_trace_context, bundle_log_fields, \
-                                 new_bundle_trace_id, record_bundle_deleted, \
-                                 record_bundle_processing_trace
-from ...models import DataServerMetadatum, DataPoint, DataBundle, DataSource, \
-                      install_supports_jsonfield, TOTAL_DATA_POINT_COUNT_DATUM, \
-                      SOURCES_DATUM, SOURCE_GENERATORS_DATUM
+from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
+                                 StopProcessingCurrentBundle, new_bundle_trace_id, \
+                                 record_bundle_deleted, record_bundle_processing_trace
+from ...models import DataBundle, DataPoint, DataServerMetadatum, TOTAL_DATA_POINT_COUNT_DATUM
 
 
 def save_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
@@ -83,6 +71,24 @@ def save_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
         return False
 
 
+def multiprocessing_bad_payload_handler(bundle_point, bundle):
+    if bundle_point is not None:
+        point_json = json.dumps(bundle_point)
+        point_json = point_json.encode('utf-16', 'surrogatepass').decode('utf-16')
+
+        try:
+            bundle_point = json.loads(point_json)
+        except json.decoder.JSONDecodeError:
+            bundle = DataBundle.objects.get(pk=bundle.pk)
+            bundle.processed = False
+            bundle.errored = timezone.now()
+            bundle.save()
+
+            raise StopProcessingCurrentBundle()
+
+    return bundle_point
+
+
 class Command(BaseCommand):
     help = 'Convert unprocessed DataBundle instances into DataPoint instances.'
 
@@ -107,345 +113,65 @@ class Command(BaseCommand):
 
     @handle_lock
     @log_scheduled_event
-    def handle(self, *args, **options): # pylint: disable=too-many-locals, too-many-branches, too-many-statements
-        to_delete = []
-
+    def handle(self, *args, **options):
+        core = BundleProcessingCore.from_settings()
         pool = ThreadPool(processes=1)
-
-        supports_json = install_supports_jsonfield()
-
-        default_tz = timezone.get_default_timezone()
-
-        seen_sources = []
-        seen_generators = []
-        source_identifiers = {}
-
-        latest_points = {}
-
-        new_point_count = 0
-        processed_bundle_count = 0
-        process_limit = 1000
-        remote_bundle_size = 100
-        remote_timeout = 5
         pending_processed_updates = []
-
-        try:
-            process_limit = settings.PDK_BUNDLE_PROCESS_LIMIT
-        except AttributeError:
-            pass
-
-        try:
-            remote_bundle_size = settings.PDK_REMOTE_BUNDLE_SIZE
-        except AttributeError:
-            pass
-
-        try:
-            remote_timeout = settings.PDK_REMOTE_BUNDLE_TIMEOUT
-        except AttributeError:
-            pass
-
-        sources = {}
-
-        # start_time = timezone.now()
-
-        private_key = None
-        public_key = None
-
-        xmit_points = {}
-
-        start_processing = timezone.now()
-
-        bundles_size = 0
 
         bundle_pks = DataBundle.objects.filter(processed=False, errored=None).order_by('-pk')[:options['bundle_count']].values_list('pk', flat=True)
 
-        for bundle_pk in bundle_pks: # pylint: disable=too-many-nested-blocks
+        for bundle_pk in bundle_pks:
+            if core.new_point_count >= core.process_limit:
+                break
+
             bundle = DataBundle.objects.get(pk=bundle_pk)
+            core.processed_bundle_count += 1
+            bundle_trace_id = new_bundle_trace_id()
 
-            if new_point_count < process_limit:
-                processed_bundle_count += 1
+            try:
+                result = core.process_bundle(bundle, bundle_trace_id, multiprocessing_bad_payload_handler)
 
-                original_properties = bundle.properties
-                bundle_trace_id = new_bundle_trace_id()
-
-                bundle_files = bundle.data_files.all()
-
-                has_bundles = (bundle_files.count() > 0)
-
-                try:
-                    if supports_json is False:
-                        bundle.properties = json.loads(bundle.properties)
-
-                    if bundle.encrypted:
-                        if 'nonce' in bundle.properties and 'encrypted' in bundle.properties:
-                            payload = base64.b64decode(bundle.properties['encrypted'])
-                            nonce = base64.b64decode(bundle.properties['nonce'])
-
-                            if private_key is None:
-                                private_key = PrivateKey(base64.b64decode(settings.PDK_SERVER_KEY).strip()) # pylint: disable=line-too-long
-
-                            if public_key is None:
-                                public_key = PublicKey(base64.b64decode(settings.PDK_CLIENT_KEY).strip()) # pylint: disable=line-too-long
-
-                            box = Box(private_key, public_key)
-
-                            decrypted_message = box.decrypt(payload, nonce)
-
-                            decrypted = six.text_type(decrypted_message, encoding='utf8')
-
-                            if bundle.compression != 'none':
-                                compressed = base64.b64decode(decrypted)
-
-                                if bundle.compression == 'gzip':
-                                    fio = BytesIO(compressed)  # io.BytesIO for Python 3
-                                    gzip_file_obj = gzip.GzipFile(fileobj=fio)
-                                    payload = gzip_file_obj.read()
-                                    gzip_file_obj.close()
-
-                                    decrypted = payload
-
-                            bundle.properties = json.loads(decrypted)
-                        elif 'encrypted' in bundle.properties:
-                            logging.critical('Missing "nonce" in encrypted bundle. Cannot decrypt bundle %s. Skipping...', bundle.pk)
-                            break
-                        elif 'nonce' in bundle.properties:
-                            logging.critical('Missing "encrypted" in encrypted bundle. Cannot decrypt bundle %s. Skipping...', bundle.pk)
-                            break
-                    elif bundle.compression != 'none':
-                        compressed = base64.b64decode(bundle.properties['payload'])
-
-                        if bundle.compression == 'gzip':
-                            fio = BytesIO(compressed)  # io.BytesIO for Python 3
-                            gzip_file_obj = gzip.GzipFile(fileobj=fio)
-                            payload = gzip_file_obj.read()
-                            gzip_file_obj.close()
-
-                            bundles_size += len(payload)
-
-                            bundle.properties = json.loads(payload)
-
-                    logging.info(
-                        'Processing bundle trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
-                        *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
+                if len(result.to_record) > 0: # pylint: disable=len-as-condition
+                    save_result = pool.apply_async(
+                        save_points,
+                        [result.to_record, result.has_bundles, result.bundle_files, bundle, bundle_trace_id],
                     )
-                    record_bundle_processing_trace(bundle, bundle_trace_id, 'started', properties=bundle.properties)
 
-                    now = timezone.now()
+                    for point in result.to_record:
+                        core.record_created_point(point)
+                else:
+                    save_result = None
 
-                    to_record = []
+                bundle.properties = result.original_properties
+                bundle.save()
 
-                    for bundle_point in bundle.properties: # pylint: disable=too-many-nested-blocks
-                        if bundle_point is not None:
-                            point_json = json.dumps(bundle_point)
+                if result.mark_processed:
+                    if save_result is None:
+                        bundle = DataBundle.objects.get(pk=bundle.pk)
+                        bundle.processed = True
+                        bundle.save()
+                        record_bundle_processing_trace(bundle, bundle_trace_id, 'processed')
 
-                            point_json = point_json.encode('utf-16', 'surrogatepass').decode('utf-16')
-
-                            try:
-                                bundle_point = json.loads(point_json)
-                            except json.decoder.JSONDecodeError:
-                                bundle_point = None
-
-                                bundle = DataBundle.objects.get(pk=bundle.pk)
-                                bundle.processed = False
-                                bundle.errored = timezone.now()
-                                bundle.save()
-
-                                break
-
-                        try:
-                            if bundle_point is not None and 'passive-data-metadata' in bundle_point and 'source' in bundle_point['passive-data-metadata'] and 'generator' in bundle_point['passive-data-metadata']:
-                                source = bundle_point['passive-data-metadata']['source']
-
-                                if source == '':
-                                    source = 'missing-source'
-
-                                try:
-                                    source = settings.PDK_RENAME_SOURCE(source)
-
-                                    bundle_point['passive-data-metadata']['source'] = source
-                                except AttributeError:
-                                    pass # Optional method not defined
-
-                                try:
-                                    attach_trace_context(bundle_point, bundle, bundle_trace_id)
-                                    settings.PDK_INSPECT_DATA_POINT_AT_INGEST(bundle_point)
-                                except AttributeError:
-                                    pass # Optional method not defined
-
-                                server_url = None
-
-                                if source in sources:
-                                    server_url = sources[source]
-                                else:
-                                    source_obj = DataSource.objects.filter(identifier=source).first()
-
-                                    if source_obj is not None:
-                                        if source_obj.server is not None:
-                                            server_url = source_obj.server.upload_url
-                                    else:
-                                        if source is not None:
-                                            source_obj = DataSource(name=source, identifier=source)
-                                            source_obj.save()
-
-                                            source_obj.join_default_group()
-
-                                    if server_url is None:
-                                        server_url = ''
-
-                                    sources[source] = server_url
-
-                                if server_url == '':
-                                    point = DataPoint(recorded=now)
-                                    bundle_point['passive-data-metadata']['encrypted_transmission'] = bundle.encrypted
-
-                                    point.source = bundle_point['passive-data-metadata']['source']
-
-                                    if point.source is None:
-                                        point.source = '-'
-
-                                    point.generator = bundle_point['passive-data-metadata']['generator']
-
-                                    if 'generator-id' in bundle_point['passive-data-metadata']:
-                                        point.generator_identifier = bundle_point['passive-data-metadata']['generator-id']
-
-                                    if 'latitude' in bundle_point['passive-data-metadata'] and 'longitude' in bundle_point['passive-data-metadata']:
-                                        point.generated_at = GEOSGeometry('POINT(' + str(bundle_point['passive-data-metadata']['longitude']) + ' ' + str(bundle_point['passive-data-metadata']['latitude']) + ')')
-                                    elif 'latitude' in bundle_point and 'longitude' in bundle_point:
-                                        point.generated_at = GEOSGeometry('POINT(' + str(bundle_point['longitude']) + ' ' + str(bundle_point['latitude']) + ')')
-
-                                    point.created = datetime.datetime.fromtimestamp(bundle_point['passive-data-metadata']['timestamp'], tz=default_tz)
-
-                                    if supports_json:
-                                        point.properties = json.loads(json.dumps(bundle_point, indent=2).encode('utf-16', 'surrogatepass').decode('utf-16'))
-                                    else:
-                                        point.properties = json.dumps(bundle_point, indent=2)
-
-                                    point.fetch_secondary_identifier(skip_save=True, properties=bundle_point)
-                                    point.fetch_user_agent(skip_save=True, properties=bundle_point)
-                                    point.fetch_generator_definition(skip_save=True)
-                                    point.fetch_source_reference(skip_save=True)
-
-                                    to_record.append(point)
-
-                                else:
-                                    if (server_url in xmit_points) is False:
-                                        xmit_points[server_url] = []
-
-                                    xmit_points[server_url].append(bundle_point)
-
-                                new_point_count += 1
-                        except DataError:
-                            traceback.print_exc()
-                            logging.debug('Error ingesting bundle: %s:', bundle.pk)
-                            logging.debug(str(bundle.properties))
-                            logging.critical(
-                                'Error ingesting bundle trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
-                                *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
-                            )
-                            record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', properties=bundle.properties, error_class='DataError')
-
-                    if len(to_record) > 0: # pylint: disable=len-as-condition
-                        save_result = pool.apply_async(save_points, [to_record, has_bundles, bundle_files, bundle, bundle_trace_id])
-
-                        for point in to_record:
-                            if (point.source in seen_sources) is False:
-                                seen_sources.append(point.source)
-
-                            if (point.source in source_identifiers) is False:
-                                source_identifiers[point.source] = []
-
-                            latest_key = point.source + '--' + point.generator_identifier
-
-                            if (latest_key in latest_points) is False or latest_points[latest_key].created < point.created:
-                                latest_points[latest_key] = point
-
-                            if (point.generator_identifier in seen_generators) is False:
-                                seen_generators.append(point.generator_identifier)
-
-                            if (point.generator_identifier in source_identifiers[point.source]) is False:
-                                source_identifiers[point.source].append(point.generator_identifier)
+                        if options['delete']:
+                            record_bundle_deleted(bundle, bundle_trace_id)
+                            core.to_delete.append(bundle)
                     else:
-                        save_result = None
-
-                    mark_processed = False
-
-                    if len(xmit_points) == 0: # pylint: disable=len-as-condition
-                        mark_processed = True
-                    else:
-                        failed = False
-
-                        for server_url, points in xmit_points.items():
-                            if len(points) > remote_bundle_size:
-                                payload = {
-                                    'payload': json.dumps(points, indent=2)
-                                }
-
-                                try:
-                                    bundle_post = requests.post(server_url, data=payload, timeout=remote_timeout)
-
-                                    if bundle_post.status_code < 200 and bundle_post.status_code >= 300:
-                                        failed = True
-
-                                    xmit_points[server_url] = []
-                                except requests.exceptions.Timeout:
-                                    logging.critical('Unable to transmit data to %s (timeout=%s).', server_url, remote_timeout)
-
-                                    failed = True
-
-                        if failed is False:
-                            mark_processed = True
-                        else:
-                            logging.critical(
-                                'Error encountered uploading contents of trace_id=%s bundle_id=%s encrypted=%s compression=%s point_count=%s source_count=%s generator_count=%s',
-                                *bundle_log_fields(bundle, bundle.properties, bundle_trace_id)
-                            )
-                            record_bundle_processing_trace(bundle, bundle_trace_id, 'upload_failed', properties=bundle.properties)
-
-                    # if bundle.encrypted is False and supports_json is False:
-                    #    bundle.properties = json.dumps(bundle.properties, indent=2)
-
-                    bundle.properties = original_properties
-
-                    bundle.save()
-
-                    if mark_processed:
-                        if save_result is None:
-                            bundle = DataBundle.objects.get(pk=bundle.pk)
-                            bundle.processed = True
-                            bundle.save()
-                            record_bundle_processing_trace(bundle, bundle_trace_id, 'processed')
-
-                            if options['delete']:
-                                record_bundle_deleted(bundle, bundle_trace_id)
-                                to_delete.append(bundle)
-                        else:
-                            pending_processed_updates.append({
-                                'bundle_pk': bundle.pk,
-                                'bundle_trace_id': bundle_trace_id,
-                                'delete_bundle': options['delete'],
-                                'save_result': save_result,
-                            })
-
-                except TransactionManagementError:
-                    logging.critical('Abandoning and marking errored %s.', bundle.pk)
-
-                    bundle = DataBundle.objects.get(pk=bundle.pk)
-
-                    bundle.errored = timezone.now()
-                    bundle.save()
-                    record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', error_class='TransactionManagementError')
-
-                except gzip.BadGzipFile:
-                    logging.critical('Bad GZip payload and marking errored %s.', bundle.pk)
-
-                    bundle = DataBundle.objects.get(pk=bundle.pk)
-
-                    bundle.errored = timezone.now()
-                    bundle.save()
-                    record_bundle_processing_trace(bundle, bundle_trace_id, 'errored', error_class='BadGzipFile')
+                        pending_processed_updates.append({
+                            'bundle_pk': bundle.pk,
+                            'bundle_trace_id': bundle_trace_id,
+                            'delete_bundle': options['delete'],
+                            'save_result': save_result,
+                        })
+            except BundleProcessingHalt:
+                break
+            except TransactionManagementError:
+                logging.critical('Abandoning and marking errored %s.', bundle.pk)
+                core.mark_bundle_errored(bundle.pk, bundle_trace_id, 'TransactionManagementError')
+            except gzip.BadGzipFile:
+                logging.critical('Bad GZip payload and marking errored %s.', bundle.pk)
+                core.mark_bundle_errored(bundle.pk, bundle_trace_id, 'BadGzipFile')
 
         pool.close()
-
         pool.join()
 
         for pending_update in pending_processed_updates:
@@ -459,122 +185,24 @@ class Command(BaseCommand):
 
                     if pending_update['delete_bundle']:
                         record_bundle_deleted(bundle, pending_update['bundle_trace_id'])
-                        to_delete.append(bundle)
+                        core.to_delete.append(bundle)
 
-        end_processing = timezone.now()
+        elapsed = (timezone.now() - core.start_processing).total_seconds()
 
-        elapsed = (end_processing - start_processing).total_seconds()
+        logging.info(
+            'Bundle Ingestion Summary: %d bundles, %.3f sec. elapsed, %.3f bundle/s, %s points added, %.3f MB, %.3f MB/s',
+            core.processed_bundle_count,
+            elapsed,
+            (core.processed_bundle_count / elapsed),
+            humanize.intcomma(core.new_point_count),
+            core.bundle_size / (1024 * 1024),
+            ((core.bundle_size / (1024 * 1024)) / elapsed),
+        )
 
-        logging.info('Bundle Ingestion Summary: %d bundles, %.3f sec. elapsed, %.3f bundle/s, %s points added, %.3f MB, %.3f MB/s', processed_bundle_count, elapsed, (processed_bundle_count / elapsed), humanize.intcomma(new_point_count), bundles_size / (1024 * 1024), ((bundles_size / (1024 * 1024)) / elapsed))
-
-        for server_url, points in xmit_points.items():
-            if points:
-                payload = {
-                    'payload': json.dumps(points, indent=2)
-                }
-
-                try:
-                    bundle_post = requests.post(server_url, data=payload, timeout=remote_timeout)
-
-                    if bundle_post.status_code < 200 and bundle_post.status_code >= 300:
-                        failed = True
-
-                    xmit_points[server_url] = []
-                except requests.exceptions.Timeout:
-                    logging.critical('Unable to transmit data to %s (timeout=%s).', server_url, remote_timeout)
-
-        for bundle in to_delete:
-            bundle.delete()
+        core.flush_remote_points()
+        core.delete_processed_bundles()
 
         if options['skip_stats'] is False:
-            data_point_count = DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).first()
-
-            if data_point_count is None:
-                count = DataPoint.objects.all().count()
-
-                data_point_count = DataServerMetadatum(key=TOTAL_DATA_POINT_COUNT_DATUM)
-
-                data_point_count.value = str(count)
-                data_point_count.save()
-            else:
-                count = int(data_point_count.value)
-
-                count += new_point_count
-
-                data_point_count.value = str(count)
-                data_point_count.save()
-
-            data_point_count = DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).first()
-
-            sources = DataServerMetadatum.objects.filter(key=SOURCES_DATUM).first()
-
-            if sources is not None:
-                updated = False
-
-                source_list = json.loads(sources.value)
-
-                for seen_source in seen_sources:
-                    if (seen_source in source_list) is False:
-                        source_list.append(seen_source)
-
-                        updated = True
-
-                if updated:
-                    sources.value = json.dumps(source_list, indent=2)
-                    sources.save()
-            else:
-                DataPoint.objects.sources()
-
-            for source, identifiers in list(source_identifiers.items()):
-                datum_key = SOURCE_GENERATORS_DATUM + ': ' + source
-                source_id_datum = DataServerMetadatum.objects.filter(key=datum_key).first()
-
-                source_ids = []
-
-                if source_id_datum is not None:
-                    source_ids = json.loads(source_id_datum.value)
-                else:
-                    source_id_datum = DataServerMetadatum(key=datum_key)
-
-                updated = False
-
-                for identifier in identifiers:
-                    if (identifier in source_ids) is False:
-                        source_ids.append(identifier)
-
-                        updated = True
-
-                if updated:
-                    source_id_datum.value = json.dumps(source_ids, indent=2)
-                    source_id_datum.save()
-
-            datum_key = SOURCE_GENERATORS_DATUM
-            generators_datum = DataServerMetadatum.objects.filter(key=datum_key).first()
-
-            generator_ids = []
-
-            if generators_datum is not None:
-                generator_ids = json.loads(generators_datum.value)
-            else:
-                generators_datum = DataServerMetadatum(key=datum_key)
-
-            updated = False
-
-            for identifier in seen_generators:
-                if (identifier in generator_ids) is False:
-                    generator_ids.append(identifier)
-
-                    updated = True
-
-            if updated:
-                generators_datum.value = json.dumps(generator_ids, indent=2)
-                generators_datum.save()
-
-            for identifier, point in list(latest_points.items()):
-                DataPoint.objects.set_latest_point(point.source, point.generator_identifier, point)
-                DataPoint.objects.set_latest_point(point.source, 'pdk-data-frequency', point)
-
-            logging.debug("%d unprocessed payloads remaining.", DataBundle.objects.filter(processed=False, errored=None).count())
-
+            core.update_stats()
         else:
             DataServerMetadatum.objects.filter(key=TOTAL_DATA_POINT_COUNT_DATUM).delete()

--- a/management/commands/pdk_process_bundles_multiprocessing.py
+++ b/management/commands/pdk_process_bundles_multiprocessing.py
@@ -2,8 +2,6 @@
 
 from __future__ import print_function
 
-from builtins import str # pylint: disable=redefined-builtin
-
 import gzip
 import json
 import logging
@@ -72,7 +70,7 @@ def save_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
         return False
 
 
-def multiprocessing_bad_payload_handler(bundle_point, bundle):
+def multiprocessing_bad_payload_handler(bundle_point, bundle):  # pylint: disable=invalid-name
     if bundle_point is not None:
         point_json = json.dumps(bundle_point)
         point_json = point_json.encode('utf-16', 'surrogatepass').decode('utf-16')
@@ -85,7 +83,7 @@ def multiprocessing_bad_payload_handler(bundle_point, bundle):
             bundle.errored = timezone.now()
             bundle.save()
 
-            raise StopProcessingCurrentBundle()
+            raise StopProcessingCurrentBundle()  # pylint: disable=raise-missing-from
 
     return bundle_point
 
@@ -114,7 +112,7 @@ class Command(BaseCommand):
 
     @handle_bundle_processing_lock
     @log_scheduled_event
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # pylint: disable=too-many-branches,too-many-statements
         core = BundleProcessingCore.from_settings()
         pool = ThreadPool(processes=1)
         pending_processed_updates = []

--- a/management/commands/pdk_process_bundles_multiprocessing.py
+++ b/management/commands/pdk_process_bundles_multiprocessing.py
@@ -18,7 +18,8 @@ from django.db import DataError
 from django.db.transaction import TransactionManagementError
 from django.utils import timezone
 
-from ...decorators import handle_lock, log_scheduled_event
+from ...db_locks import handle_bundle_processing_lock
+from ...decorators import log_scheduled_event
 from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
                                  StopProcessingCurrentBundle, new_bundle_trace_id, \
                                  record_bundle_deleted, record_bundle_processing_trace
@@ -111,7 +112,7 @@ class Command(BaseCommand):
                             default=False,
                             help='Skips statistic updates for improved speeds')
 
-    @handle_lock
+    @handle_bundle_processing_lock
     @log_scheduled_event
     def handle(self, *args, **options):
         core = BundleProcessingCore.from_settings()

--- a/views.py
+++ b/views.py
@@ -12,6 +12,7 @@ import re
 import traceback
 
 from django.conf import settings
+from django.db import transaction
 from django.db.utils import DataError
 from django.http import HttpResponse, HttpResponseNotAllowed, JsonResponse, HttpResponseNotFound, \
                         FileResponse, UnreadablePostError
@@ -220,44 +221,54 @@ def pdk_add_data_bundle(request): # pylint: disable=too-many-statements, too-man
         response['Access-Control-Request-Headers'] = 'Content-Type'
         response['Access-Control-Allow-Headers'] = 'Content-Type'
 
+        bundle = None
+
         try:
-            bundle = DataBundle(recorded=timezone.now(), encrypted=False)
+            with transaction.atomic():
+                bundle = DataBundle(recorded=timezone.now(), encrypted=False)
 
-            if 'encrypted' in request.POST:
-                bundle.encrypted = (request.POST['encrypted'] == 'true')
+                if 'encrypted' in request.POST:
+                    bundle.encrypted = (request.POST['encrypted'] == 'true')
 
-            if 'compression' in request.POST:
-                bundle.compression = request.POST['compression']
+                if 'compression' in request.POST:
+                    bundle.compression = request.POST['compression']
 
-            if bundle.encrypted:
-                payload = {
-                    'encrypted': request.POST['payload'],
-                    'nonce': request.POST['nonce']
-                }
-
-                if supports_json:
-                    bundle.properties = payload
-                else:
-                    bundle.properties = json.dumps(payload)
-            else:
-                if bundle.compression == 'none':
-                    points = json.loads(request.POST['payload'])
-
-                    if supports_json:
-                        bundle.properties = points
-                    else:
-                        bundle.properties = json.dumps(points)
-                else:
-                    properties = {
-                        'payload': request.POST['payload']
+                if bundle.encrypted:
+                    payload = {
+                        'encrypted': request.POST['payload'],
+                        'nonce': request.POST['nonce']
                     }
 
                     if supports_json:
-                        bundle.properties = properties
+                        bundle.properties = payload
                     else:
-                        bundle.properties = json.dumps(properties)
+                        bundle.properties = json.dumps(payload)
+                else:
+                    if bundle.compression == 'none':
+                        points = json.loads(request.POST['payload'])
 
-            bundle.save()
+                        if supports_json:
+                            bundle.properties = points
+                        else:
+                            bundle.properties = json.dumps(points)
+                    else:
+                        properties = {
+                            'payload': request.POST['payload']
+                        }
+
+                        if supports_json:
+                            bundle.properties = properties
+                        else:
+                            bundle.properties = json.dumps(properties)
+
+                bundle.save()
+
+                for key, value in list(request.FILES.items()): # pylint: disable=unused-variable
+                    data_file = DataFile(data_bundle=bundle)
+                    data_file.identifier = key
+                    data_file.content_type = value.content_type
+                    data_file.content_file.save(key, value)
+                    data_file.save()
         except ValueError:
             response_payload = {'message': 'Unable to parse data bundle.'}
             response = HttpResponse(json.dumps(response_payload), \
@@ -268,13 +279,6 @@ def pdk_add_data_bundle(request): # pylint: disable=too-many-statements, too-man
             response = HttpResponse(json.dumps(response_payload), \
                                     content_type='application/json', \
                                     status=400)
-
-        for key, value in list(request.FILES.items()): # pylint: disable=unused-variable
-            data_file = DataFile(data_bundle=bundle)
-            data_file.identifier = key
-            data_file.content_type = value.content_type
-            data_file.content_file.save(key, value)
-            data_file.save()
 
         return response
     elif request.method == 'OPTIONS':


### PR DESCRIPTION
## Summary
This PR refactors bundle processing into shared core/helpers and tightens write consistency for bundle ingestion.

The main pieces are:
- extract shared bundle-processing core logic used by the single-process and multiprocessing paths
- expose a shared serial save helper and a configurable bad-payload handler
- add an advisory lock around bundle processing to reduce concurrent processing collisions
- wrap `DataBundle` and `DataFile` writes for bundle uploads in one transaction so downstream observers never see a partially-written upload

## Why
This branch is the implementation-heavy top of the stack. It separates reusable processing behavior from command-specific wiring and closes a correctness gap where bundle rows could become visible before their attached files were fully committed.

## What Changed
- `bundle_processing.py`
  - introduce shared processing helpers and the null-byte bad-payload handler
- `management/commands/pdk_process_bundles.py`
  - move toward the shared processing core
- `management/commands/pdk_process_bundles_multiprocessing.py`
  - reuse more of the same processing behavior while preserving the bandaid base branch behavior
- `db_locks.py`
  - add the advisory-lock helper used during bundle processing
- `views.py`
  - wrap upload writes in a single transaction so bundles and files commit atomically

## Testing
- not re-run separately after restacking
- validated in a deployment that wraps Passive Data Kit
- rebased onto the updated lower branches so this PR includes the shared pylint fix from `traceable-processing`
