### PR TITLE
Use structured access request user identifiers

### DIFF
--- a/access_requests.py
+++ b/access_requests.py
@@ -1,0 +1,75 @@
+import json
+
+
+USER_IDENTIFIER_KIND_API_TOKEN = 'api-client'  # nosec B105
+USER_IDENTIFIER_KIND_DJANGO_USER = 'django-user'
+
+
+def build_django_user_identifier(user):
+    return json.dumps({
+        'kind': USER_IDENTIFIER_KIND_DJANGO_USER,
+        'user_pk': user.pk,
+        'username': str(user.username),
+    }, sort_keys=True, separators=(',', ':'))
+
+
+def build_token_identifier(token_value):
+    return json.dumps({
+        'kind': USER_IDENTIFIER_KIND_API_TOKEN,
+        'token': str(token_value or ''),
+    }, sort_keys=True, separators=(',', ':'))
+
+
+def parse_user_identifier(value):
+    raw_value = str(value or '')
+
+    if raw_value.strip() == '':
+        return {
+            'kind': '',
+            'raw_value': raw_value,
+        }
+
+    try:
+        parsed = json.loads(raw_value)
+
+        if isinstance(parsed, dict):
+            parsed['raw_value'] = raw_value
+
+            return parsed
+    except (TypeError, ValueError):
+        pass
+
+    if raw_value.startswith('api_token: '):
+        return {
+            'kind': USER_IDENTIFIER_KIND_API_TOKEN,
+            'token': raw_value[len('api_token: '):],
+            'raw_value': raw_value,
+        }
+
+    if ': ' in raw_value:
+        user_pk, username = raw_value.split(': ', 1)
+
+        if user_pk.isdigit():
+            return {
+                'kind': USER_IDENTIFIER_KIND_DJANGO_USER,
+                'user_pk': int(user_pk),
+                'username': username,
+                'raw_value': raw_value,
+            }
+
+    return {
+        'kind': '',
+        'raw_value': raw_value,
+    }
+
+
+def format_user_identifier(value):
+    parsed = parse_user_identifier(value)
+
+    if parsed.get('kind') == USER_IDENTIFIER_KIND_DJANGO_USER:
+        return '#%s %s' % (parsed.get('user_pk', ''), parsed.get('username', ''))
+
+    if parsed.get('kind') == USER_IDENTIFIER_KIND_API_TOKEN:
+        return 'api_token %s' % parsed.get('token', '')
+
+    return parsed.get('raw_value', '')

--- a/admin.py
+++ b/admin.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     from django.contrib.admin import ModelAdmin as ModelAdmin # pylint: disable=useless-import-alias
 
+from .access_requests import format_user_identifier
 from .models import DataPoint, DataBundle, DataSource, DataSourceGroup, \
                     DataPointVisualization, ReportJob, DataSourceAlert, \
                     DataServerMetadatum, ReportJobBatchRequest, DataServerApiToken, \
@@ -344,16 +345,21 @@ class ReportDestinationAdmin(GISModelAdmin):
     list_display = ('user', 'destination', 'description')
     search_fields = ('destination', 'user',)
 
+def display_user_identifier(obj):
+    return format_user_identifier(obj.user_identifier)
+
+display_user_identifier.short_description = 'User Identifier'
+
 @admin.register(DataServerAccessRequestPending)
 class DataServerAccessRequestPendingAdmin(GISModelAdmin):
-    list_display = ('user_identifier', 'request_type', 'request_time', 'successful', 'processed',)
+    list_display = (display_user_identifier, 'request_type', 'request_time', 'successful', 'processed',)
 
     search_fields = ('user_identifier', 'request_metadata',)
     list_filter = ('request_time', 'request_type', 'successful', 'processed',)
 
 @admin.register(DataServerAccessRequest)
 class DataServerAccessRequestAdmin(GISModelAdmin):
-    list_display = ('user_identifier', 'request_type', 'request_time', 'successful',)
+    list_display = (display_user_identifier, 'request_type', 'request_time', 'successful',)
 
     search_fields = ('user_identifier', 'request_metadata',)
     list_filter = ('request_time', 'request_type', 'successful',)

--- a/api_views.py
+++ b/api_views.py
@@ -2,8 +2,6 @@
 
 from __future__ import print_function
 
-from builtins import str # pylint: disable=redefined-builtin
-
 import datetime
 import importlib
 import json
@@ -19,6 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from django.contrib.auth import authenticate
 
+from passive_data_kit.access_requests import build_django_user_identifier, build_token_identifier
 from passive_data_kit.models import DataServerApiToken, DataPoint, DataServerAccessRequestPending, DataSource, DataSourceGroup, DataSourceReference, DataGeneratorDefinition
 
 
@@ -178,9 +177,9 @@ def pdk_data_point_query(request): # pylint: disable=too-many-locals, too-many-b
         access_request = DataServerAccessRequestPending()
 
         if token is not None:
-            access_request.user_identifier = str(token.user.pk) + ': ' + str(token.user.username)
+            access_request.user_identifier = build_django_user_identifier(token.user)
         else:
-            access_request.user_identifier = 'api_token: ' + request.POST.get('token', None)
+            access_request.user_identifier = build_token_identifier(request.POST.get('token', None))
 
         access_request.request_type = 'api-data-points-request'
         access_request.request_time = timezone.now()
@@ -271,9 +270,9 @@ def pdk_data_source_query(request): # pylint: disable=too-many-locals, too-many-
         access_request = DataServerAccessRequestPending()
 
         if token is not None:
-            access_request.user_identifier = str(token.user.pk) + ': ' + str(token.user.username)
+            access_request.user_identifier = build_django_user_identifier(token.user)
         else:
-            access_request.user_identifier = 'api_token: ' + request.POST.get('token', None)
+            access_request.user_identifier = build_token_identifier(request.POST.get('token', None))
 
         access_request.request_type = 'api-data-source-request'
         access_request.request_time = timezone.now()
@@ -360,9 +359,9 @@ def pdk_data_source_update(request): # pylint: disable=too-many-locals, too-many
         access_request = DataServerAccessRequestPending()
 
         if token is not None:
-            access_request.user_identifier = str(token.user.pk) + ': ' + str(token.user.username)
+            access_request.user_identifier = build_django_user_identifier(token.user)
         else:
-            access_request.user_identifier = 'api_token: ' + request.POST.get('token', None)
+            access_request.user_identifier = build_token_identifier(request.POST.get('token', None))
 
         access_request.request_type = 'api-data-source-update'
         access_request.request_time = timezone.now()

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,12 @@
 from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from passive_data_kit.access_requests import build_django_user_identifier, \
+                                             build_token_identifier, \
+                                             format_user_identifier, \
+                                             parse_user_identifier, \
+                                             USER_IDENTIFIER_KIND_API_TOKEN, \
+                                             USER_IDENTIFIER_KIND_DJANGO_USER
 
 class TestBasicsTestCase(TestCase):
     def setUp(self):
@@ -6,3 +14,37 @@ class TestBasicsTestCase(TestCase):
 
     def test_tests_working(self):
         self.assertNotEqual('foo', 'bar')
+
+
+class AccessRequestIdentifiersTestCase(TestCase):
+    def test_django_user_identifier(self):
+        user = get_user_model().objects.create_user(username='saml:entra-object-id')
+
+        identifier = build_django_user_identifier(user)
+        parsed = parse_user_identifier(identifier)
+
+        self.assertEqual(parsed['kind'], USER_IDENTIFIER_KIND_DJANGO_USER)
+        self.assertEqual(parsed['user_pk'], user.pk)
+        self.assertEqual(parsed['username'], 'saml:entra-object-id')
+        self.assertEqual(format_user_identifier(identifier), '#%s saml:entra-object-id' % user.pk)
+
+    def test_api_token_identifier(self):
+        identifier = build_token_identifier('example-token')
+        parsed = parse_user_identifier(identifier)
+
+        self.assertEqual(parsed['kind'], USER_IDENTIFIER_KIND_API_TOKEN)
+        self.assertEqual(parsed['token'], 'example-token')
+        self.assertEqual(format_user_identifier(identifier), 'api_token example-token')
+
+    def test_parse_legacy_user_id(self):
+        parsed = parse_user_identifier('42: saml:entra-object-id')
+
+        self.assertEqual(parsed['kind'], USER_IDENTIFIER_KIND_DJANGO_USER)
+        self.assertEqual(parsed['user_pk'], 42)
+        self.assertEqual(parsed['username'], 'saml:entra-object-id')
+
+    def test_parse_legacy_token_id(self):
+        parsed = parse_user_identifier('api_token: example-token')
+
+        self.assertEqual(parsed['kind'], USER_IDENTIFIER_KIND_API_TOKEN)
+        self.assertEqual(parsed['token'], 'example-token')


### PR DESCRIPTION
## Summary
- replace colon-delimited access request user identifiers with structured JSON values
- add helpers to build, parse, and format those identifiers
- keep the admin list readable while preserving backward-compatible parsing of legacy values
- this lets projects on top of PassiveDataKit-Django integrate SAML support, which introduces a colon into user names, and creates issues. 

## Testing
- bash scripts/keystone_local.sh manage test passive_data_kit.tests
