### PR TITLE
Avoid double-saving uploaded bundle files

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member, invalid-name
+
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from passive_data_kit.access_requests import build_django_user_identifier, \
                                              build_token_identifier, \
@@ -7,6 +8,7 @@ from passive_data_kit.access_requests import build_django_user_identifier, \
                                              parse_user_identifier, \
                                              USER_IDENTIFIER_KIND_API_TOKEN, \
                                              USER_IDENTIFIER_KIND_DJANGO_USER
+from passive_data_kit.models import DataBundle, DataFile
 
 class TestBasicsTestCase(TestCase):
     def setUp(self):
@@ -48,3 +50,22 @@ class AccessRequestIdentifiersTestCase(TestCase):
 
         self.assertEqual(parsed['kind'], USER_IDENTIFIER_KIND_API_TOKEN)
         self.assertEqual(parsed['token'], 'example-token')
+
+
+class BundleUploadTests(TestCase):
+    def test_add_bundle_uploads_data_file(self):
+        data_file = SimpleUploadedFile(
+            'example.txt',
+            b'example file contents',
+            content_type='text/plain',
+        )
+
+        response = self.client.post('/data/add-bundle.json', {
+            'payload': '[]',
+            'attachment': data_file,
+        })
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(DataBundle.objects.count(), 1)
+        self.assertEqual(DataFile.objects.count(), 1)
+        self.assertEqual(DataFile.objects.first().identifier, 'attachment')

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member, invalid-name
+# pylint: disable=no-member, invalid-name, line-too-long
 
 from django.test import TestCase
 from django.contrib.auth import get_user_model

--- a/views.py
+++ b/views.py
@@ -267,7 +267,7 @@ def pdk_add_data_bundle(request): # pylint: disable=too-many-statements, too-man
                     data_file = DataFile(data_bundle=bundle)
                     data_file.identifier = key
                     data_file.content_type = value.content_type
-                    data_file.content_file.save(key, value)
+                    data_file.content_file.save(key, value, save=False)
                     data_file.save()
         except ValueError:
             response_payload = {'message': 'Unable to parse data bundle.'}


### PR DESCRIPTION
## Summary
- save uploaded bundle attachment files with save=False before the explicit DataFile save
- add a regression test for bundle uploads with attachments

## Tests
- python3 -m py_compile views.py tests.py
- git diff --check origin/generalized-bundle-processing..HEAD
- bash scripts/keystone_local.sh manage test passive_data_kit.tests.BundleUploadTests