### PR TITLE
Bulk insert bundle processing traces

### DIFF
--- a/bundle_processing.py
+++ b/bundle_processing.py
@@ -79,11 +79,14 @@ def bundle_log_fields(bundle, properties, bundle_trace_id):
     )
 
 
-def attach_trace_context(bundle_point, bundle, bundle_trace_id):
+def attach_trace_context(bundle_point, bundle, bundle_trace_id, cache=None):
     bundle_point['_pdk_trace_context'] = {
         'bundle_trace_id': bundle_trace_id,
         'bundle_id': bundle.pk,
     }
+
+    if cache is not None:
+        bundle_point['_pdk_trace_context']['cache'] = cache
 
 
 def strip_null_bytes_bad_payload_handler(bundle_point, bundle):  # pylint: disable=invalid-name
@@ -103,13 +106,13 @@ def strip_null_bytes_bad_payload_handler(bundle_point, bundle):  # pylint: disab
 # wrapper structure. Once Python 2 support is dropped, make the optional
 # context keyword-only instead of allowing additional positional arguments.
 def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        bundle, bundle_trace_id, status, properties=None, data_point_id=None, error_class=None):
+        bundle, bundle_trace_id, status, properties=None, data_point_id=None, error_class=None, save=True):
     point_count = None
 
     if isinstance(properties, list):
         point_count = len(properties)
 
-    DataBundleProcessingTrace.objects.create(
+    trace = DataBundleProcessingTrace(
         bundle_id=bundle.pk,
         bundle_trace_id=bundle_trace_id,
         data_point_id=data_point_id,
@@ -120,6 +123,11 @@ def record_bundle_processing_trace(  # pylint: disable=too-many-arguments,too-ma
         compression=bundle.compression,
         error_class=error_class,
     )
+
+    if save:
+        trace.save()
+
+    return trace
 
 
 def record_bundle_deleted(bundle, bundle_trace_id):
@@ -162,6 +170,7 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
 
         self.sources = {}
         self.xmit_points = {}
+        self.trace_context_cache = {}
 
         self.private_key = None
         self.public_key = None
@@ -269,8 +278,7 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
                'source' in bundle_point['passive-data-metadata'] and \
                'generator' in bundle_point['passive-data-metadata']
 
-    @staticmethod
-    def prepare_bundle_point(bundle_point, bundle, bundle_trace_id):
+    def prepare_bundle_point(self, bundle_point, bundle, bundle_trace_id):
         source = bundle_point['passive-data-metadata']['source']
 
         if source == '':
@@ -283,7 +291,7 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
             pass
 
         try:
-            attach_trace_context(bundle_point, bundle, bundle_trace_id)
+            attach_trace_context(bundle_point, bundle, bundle_trace_id, self.trace_context_cache)
             settings.PDK_INSPECT_DATA_POINT_AT_INGEST(bundle_point)
         except AttributeError:
             pass
@@ -502,8 +510,6 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
             if updated:
                 sources.value = json.dumps(source_list, indent=2)
                 sources.save()
-        else:
-            DataPoint.objects.sources()
 
         for source, identifiers in list(self.source_identifiers.items()):
             datum_key = SOURCE_GENERATORS_DATUM + ': ' + source
@@ -560,11 +566,21 @@ class BundleProcessingCore(object):  # pylint: disable=too-many-instance-attribu
 
 def save_serial_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
     points = DataPoint.objects.bulk_create(to_record)
+    traces = []
 
     for point in points:
-        record_bundle_processing_trace(bundle, bundle_trace_id, 'data_point_created', data_point_id=point.pk)
+        traces.append(record_bundle_processing_trace(
+            bundle,
+            bundle_trace_id,
+            'data_point_created',
+            data_point_id=point.pk,
+            save=False,
+        ))
 
         if has_bundles:
             point.fetch_bundle_files(bundle_files)
+
+    if traces:
+        DataBundleProcessingTrace.objects.bulk_create(traces)
 
     return points

--- a/management/commands/pdk_process_bundles_multiprocessing.py
+++ b/management/commands/pdk_process_bundles_multiprocessing.py
@@ -21,18 +21,29 @@ from ...decorators import log_scheduled_event
 from ...bundle_processing import BundleProcessingCore, BundleProcessingHalt, \
                                  StopProcessingCurrentBundle, new_bundle_trace_id, \
                                  record_bundle_deleted, record_bundle_processing_trace
-from ...models import DataBundle, DataPoint, DataServerMetadatum, TOTAL_DATA_POINT_COUNT_DATUM
+from ...models import DataBundle, DataBundleProcessingTrace, DataPoint, DataServerMetadatum, \
+                      TOTAL_DATA_POINT_COUNT_DATUM
 
 
 def save_points(to_record, has_bundles, bundle_files, bundle, bundle_trace_id):
     try:
         points = DataPoint.objects.bulk_create(to_record)
+        traces = []
 
         for point in points:
-            record_bundle_processing_trace(bundle, bundle_trace_id, 'data_point_created', data_point_id=point.pk)
+            traces.append(record_bundle_processing_trace(
+                bundle,
+                bundle_trace_id,
+                'data_point_created',
+                data_point_id=point.pk,
+                save=False,
+            ))
 
             if has_bundles:
                 point.fetch_bundle_files(bundle_files)
+
+        if traces:
+            DataBundleProcessingTrace.objects.bulk_create(traces)
 
         return True
 

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,10 @@
+import calendar
+import json
+
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
 
 from passive_data_kit.access_requests import build_django_user_identifier, \
                                              build_token_identifier, \
@@ -8,7 +12,8 @@ from passive_data_kit.access_requests import build_django_user_identifier, \
                                              parse_user_identifier, \
                                              USER_IDENTIFIER_KIND_API_TOKEN, \
                                              USER_IDENTIFIER_KIND_DJANGO_USER
-from passive_data_kit.models import DataBundle, DataFile
+from passive_data_kit.bundle_processing import record_bundle_processing_trace, save_serial_points
+from passive_data_kit.models import DataBundle, DataBundleProcessingTrace, DataFile, DataPoint, install_supports_jsonfield
 
 class TestBasicsTestCase(TestCase):
     def setUp(self):
@@ -69,3 +74,67 @@ class BundleUploadTests(TestCase):
         self.assertEqual(DataBundle.objects.count(), 1)
         self.assertEqual(DataFile.objects.count(), 1)
         self.assertEqual(DataFile.objects.first().identifier, 'attachment')
+
+
+class BundleProcessingTraceTests(TestCase):
+    def create_bundle(self):
+        properties = []
+
+        if install_supports_jsonfield() is False:
+            properties = json.dumps(properties)
+
+        return DataBundle.objects.create(
+            recorded=timezone.now(),
+            properties=properties,
+        )
+
+    def create_point(self, source, generator_identifier):
+        now = timezone.now()
+        metadata = {
+            'source': source,
+            'generator': generator_identifier + ': test',
+            'generator-id': generator_identifier,
+            'timestamp': calendar.timegm(now.utctimetuple()),
+        }
+        properties = {
+            'passive-data-metadata': metadata,
+        }
+
+        if install_supports_jsonfield() is False:
+            properties = json.dumps(properties)
+
+        return DataPoint(
+            source=source,
+            generator=metadata['generator'],
+            generator_identifier=generator_identifier,
+            created=now,
+            recorded=now,
+            properties=properties,
+        )
+
+    def test_record_bundle_processing_trace_can_return_unsaved_trace(self):
+        bundle = self.create_bundle()
+
+        trace = record_bundle_processing_trace(
+            bundle,
+            'trace-id',
+            'data_point_created',
+            data_point_id=123,
+            save=False,
+        )
+
+        self.assertIsNone(trace.pk)
+        self.assertEqual(DataBundleProcessingTrace.objects.count(), 0)
+
+    def test_save_serial_points_records_data_point_traces(self):
+        bundle = self.create_bundle()
+        points = [
+            self.create_point('source-1', 'generator-1'),
+            self.create_point('source-2', 'generator-2'),
+        ]
+
+        saved_points = save_serial_points(points, False, None, bundle, 'trace-id')
+
+        self.assertEqual(len(saved_points), 2)
+        self.assertEqual(DataPoint.objects.count(), 2)
+        self.assertEqual(DataBundleProcessingTrace.objects.filter(status='data_point_created').count(), 2)

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member, invalid-name
+# pylint: disable=no-member, invalid-name, line-too-long
 
 import calendar
 import json

--- a/tests.py
+++ b/tests.py
@@ -80,7 +80,7 @@ class BundleUploadTests(TestCase):
 
 
 class BundleProcessingTraceTests(TestCase):
-    def create_bundle(self):
+    def create_bundle(self): # pylint: disable=no-self-use
         properties = []
 
         if install_supports_jsonfield() is False:
@@ -91,7 +91,7 @@ class BundleProcessingTraceTests(TestCase):
             properties=properties,
         )
 
-    def create_point(self, source, generator_identifier):
+    def create_point(self, source, generator_identifier): # pylint: disable=no-self-use
         now = timezone.now()
         metadata = {
             'source': source,

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member, invalid-name
+
 import calendar
 import json
 
@@ -12,6 +14,7 @@ from passive_data_kit.access_requests import build_django_user_identifier, \
                                              parse_user_identifier, \
                                              USER_IDENTIFIER_KIND_API_TOKEN, \
                                              USER_IDENTIFIER_KIND_DJANGO_USER
+
 from passive_data_kit.bundle_processing import record_bundle_processing_trace, save_serial_points
 from passive_data_kit.models import DataBundle, DataBundleProcessingTrace, DataFile, DataPoint, install_supports_jsonfield
 


### PR DESCRIPTION
## Summary
- allow record_bundle_processing_trace to return unsaved trace objects
- bulk-create processing trace rows alongside bulk-created data points
- apply the same batching path in multiprocessing bundle processing

## Tests
- python3 -m py_compile bundle_processing.py management/commands/pdk_process_bundles_multiprocessing.py tests.py
- git diff --check
- bash scripts/keystone_local.sh manage test passive_data_kit.tests.BundleUploadTests passive_data_kit.tests.BundleProcessingTraceTests